### PR TITLE
<feat>[sign up/in]: Implement shadcn OTP input field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,11 @@ Relevant docs:
 - [Change scope and validation](docs/agents/workflow-and-validation.md)
 
 <!-- convex-ai-start -->
+
 This project uses [Convex](https://convex.dev) as its backend.
 
 When working on Convex code, **always read `src/convex/_generated/ai/guidelines.md` first** for important guidelines on how to correctly use Convex APIs and patterns. The file contains rules that override what you may have learned about Convex from training data.
 
 Convex agent skills for common tasks can be installed by running `npx convex ai-files install`.
+
 <!-- convex-ai-end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,11 @@ See `AGENTS.md` for the canonical project policies and implementation guardrails
 None currently.
 
 <!-- convex-ai-start -->
+
 This project uses [Convex](https://convex.dev) as its backend.
 
 When working on Convex code, **always read `src/convex/_generated/ai/guidelines.md` first** for important guidelines on how to correctly use Convex APIs and patterns. The file contains rules that override what you may have learned about Convex from training data.
 
 Convex agent skills for common tasks can be installed by running `npx convex ai-files install`.
+
 <!-- convex-ai-end -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"dependencies": {
 				"convex": "^1.34.1",
 				"convex-svelte": "0.0.12",
-				"input-otp": "^1.4.2",
 				"mode-watcher": "^1.1.0",
 				"svelte-clerk": "^1.1.1"
 			},
@@ -1464,16 +1463,6 @@
 			"version": "0.2.7",
 			"license": "MIT"
 		},
-		"node_modules/input-otp": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
-			"integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
-			}
-		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"dev": true,
@@ -2100,29 +2089,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/react": {
-			"version": "19.2.5",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-			"integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/react-dom": {
-			"version": "19.2.5",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-			"integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"scheduler": "^0.27.0"
-			},
-			"peerDependencies": {
-				"react": "^19.2.5"
-			}
-		},
 		"node_modules/readdirp": {
 			"version": "4.1.2",
 			"dev": true,
@@ -2211,13 +2177,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/scheduler": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/semver": {
 			"version": "7.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"convex": "^1.34.1",
 				"convex-svelte": "0.0.12",
+				"input-otp": "^1.4.2",
 				"mode-watcher": "^1.1.0",
 				"svelte-clerk": "^1.1.1"
 			},
@@ -1463,6 +1464,16 @@
 			"version": "0.2.7",
 			"license": "MIT"
 		},
+		"node_modules/input-otp": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
+			"integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"dev": true,
@@ -2089,6 +2100,29 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/react": {
+			"version": "19.2.5",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+			"integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-dom": {
+			"version": "19.2.5",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+			"integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"scheduler": "^0.27.0"
+			},
+			"peerDependencies": {
+				"react": "^19.2.5"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "4.1.2",
 			"dev": true,
@@ -2177,6 +2211,13 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/scheduler": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/semver": {
 			"version": "7.7.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/vite": "^4.1.18",
 		"@types/node": "^24",
+		"@types/qrcode": "^1.5.6",
 		"@types/sanitize-html": "^2.16.1",
 		"bits-ui": "^2.16.5",
 		"clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/vite": "^4.1.18",
 		"@types/node": "^24",
+		"@types/sanitize-html": "^2.16.1",
 		"bits-ui": "^2.16.5",
 		"clsx": "^2.1.1",
 		"eslint": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 	"dependencies": {
 		"convex": "^1.34.1",
 		"convex-svelte": "0.0.12",
+		"input-otp": "^1.4.2",
 		"mode-watcher": "^1.1.0",
 		"svelte-clerk": "^1.1.1"
 	}

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
 	"dependencies": {
 		"convex": "^1.34.1",
 		"convex-svelte": "0.0.12",
-		"input-otp": "^1.4.2",
-		"mode-watcher": "^1.1.0",
+"mode-watcher": "^1.1.0",
 		"svelte-clerk": "^1.1.1"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.12.0
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       bits-ui:
         specifier: ^2.16.5
         version: 2.16.5(@internationalized/date@3.12.0)(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)
@@ -1042,6 +1045,9 @@ packages:
 
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
+
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2877,6 +2883,10 @@ snapshots:
   '@types/node@24.12.0':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
 
   '@types/trusted-types@2.0.7': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.12.0
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       '@types/sanitize-html':
         specifier: ^2.16.1
         version: 2.16.1
@@ -1045,6 +1048,9 @@ packages:
 
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
+
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
 
   '@types/sanitize-html@2.16.1':
     resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
@@ -2883,6 +2889,10 @@ snapshots:
   '@types/node@24.12.0':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 24.12.0
 
   '@types/sanitize-html@2.16.1':
     dependencies:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,30 +1,30 @@
 {
-  "version": 1,
-  "skills": {
-    "convex-create-component": {
-      "source": "get-convex/agent-skills",
-      "sourceType": "github",
-      "computedHash": "d110fca7f65b4919367e6fc63a93bf54abea2cf5e4e097234c947559ffa6e527"
-    },
-    "convex-migration-helper": {
-      "source": "get-convex/agent-skills",
-      "sourceType": "github",
-      "computedHash": "46d1ac354eefbed05e1367d828e893816c13302276080bfaf6bcd828281be486"
-    },
-    "convex-performance-audit": {
-      "source": "get-convex/agent-skills",
-      "sourceType": "github",
-      "computedHash": "30ea0d3c259df011e44ea9b70502ab272f5ac3bd1fb3672ae18489ba99b2c4ae"
-    },
-    "convex-quickstart": {
-      "source": "get-convex/agent-skills",
-      "sourceType": "github",
-      "computedHash": "8ae9e1b02f526ea65e7895fac82af74142cd8e70e364d9dae9dbf79a296fb5ef"
-    },
-    "convex-setup-auth": {
-      "source": "get-convex/agent-skills",
-      "sourceType": "github",
-      "computedHash": "e719d31d1ab0d19ca7b942d1154d3ff436b5c156900eea9866c2aaeb910a1388"
-    }
-  }
+	"version": 1,
+	"skills": {
+		"convex-create-component": {
+			"source": "get-convex/agent-skills",
+			"sourceType": "github",
+			"computedHash": "d110fca7f65b4919367e6fc63a93bf54abea2cf5e4e097234c947559ffa6e527"
+		},
+		"convex-migration-helper": {
+			"source": "get-convex/agent-skills",
+			"sourceType": "github",
+			"computedHash": "46d1ac354eefbed05e1367d828e893816c13302276080bfaf6bcd828281be486"
+		},
+		"convex-performance-audit": {
+			"source": "get-convex/agent-skills",
+			"sourceType": "github",
+			"computedHash": "30ea0d3c259df011e44ea9b70502ab272f5ac3bd1fb3672ae18489ba99b2c4ae"
+		},
+		"convex-quickstart": {
+			"source": "get-convex/agent-skills",
+			"sourceType": "github",
+			"computedHash": "8ae9e1b02f526ea65e7895fac82af74142cd8e70e364d9dae9dbf79a296fb5ef"
+		},
+		"convex-setup-auth": {
+			"source": "get-convex/agent-skills",
+			"sourceType": "github",
+			"computedHash": "e719d31d1ab0d19ca7b942d1154d3ff436b5c156900eea9866c2aaeb910a1388"
+		}
+	}
 }

--- a/src/lib/components/ui/input-otp/index.ts
+++ b/src/lib/components/ui/input-otp/index.ts
@@ -1,0 +1,15 @@
+import Root from "./input-otp.svelte";
+import Group from "./input-otp-group.svelte";
+import Slot from "./input-otp-slot.svelte";
+import Separator from "./input-otp-separator.svelte";
+
+export {
+	Root,
+	Group,
+	Slot,
+	Separator,
+	Root as InputOTP,
+	Group as InputOTPGroup,
+	Slot as InputOTPSlot,
+	Separator as InputOTPSeparator,
+};

--- a/src/lib/components/ui/input-otp/index.ts
+++ b/src/lib/components/ui/input-otp/index.ts
@@ -1,7 +1,7 @@
-import Root from "./input-otp.svelte";
-import Group from "./input-otp-group.svelte";
-import Slot from "./input-otp-slot.svelte";
-import Separator from "./input-otp-separator.svelte";
+import Root from './input-otp.svelte';
+import Group from './input-otp-group.svelte';
+import Slot from './input-otp-slot.svelte';
+import Separator from './input-otp-separator.svelte';
 
 export {
 	Root,
@@ -11,5 +11,5 @@ export {
 	Root as InputOTP,
 	Group as InputOTPGroup,
 	Slot as InputOTPSlot,
-	Separator as InputOTPSeparator,
+	Separator as InputOTPSeparator
 };

--- a/src/lib/components/ui/input-otp/input-otp-group.svelte
+++ b/src/lib/components/ui/input-otp/input-otp-group.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="input-otp-group"
+	class={cn("has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 has-aria-invalid:border-destructive rounded-md has-aria-invalid:ring-2 flex items-center", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/input-otp/input-otp-group.svelte
+++ b/src/lib/components/ui/input-otp/input-otp-group.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import type { HTMLAttributes } from "svelte/elements";
-	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -13,7 +13,10 @@
 <div
 	bind:this={ref}
 	data-slot="input-otp-group"
-	class={cn("has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 has-aria-invalid:border-destructive rounded-md has-aria-invalid:ring-2 flex items-center", className)}
+	class={cn(
+		'flex items-center rounded-md has-aria-invalid:border-destructive has-aria-invalid:ring-2 has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40',
+		className
+	)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/src/lib/components/ui/input-otp/input-otp-separator.svelte
+++ b/src/lib/components/ui/input-otp/input-otp-separator.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { WithElementRef } from "$lib/utils.js";
+	import { cn } from "$lib/utils.js";
+	import MinusIcon from '@lucide/svelte/icons/minus';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="input-otp-separator"
+	role="separator"
+	class={cn("[&_svg:not([class*='size-'])]:size-4 flex items-center", className)}
+	{...restProps}
+>
+	{#if children}
+		{@render children?.()}
+	{:else}
+		<MinusIcon  />
+	{/if}
+</div>

--- a/src/lib/components/ui/input-otp/input-otp-separator.svelte
+++ b/src/lib/components/ui/input-otp/input-otp-separator.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import type { HTMLAttributes } from "svelte/elements";
-	import type { WithElementRef } from "$lib/utils.js";
-	import { cn } from "$lib/utils.js";
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { WithElementRef } from '$lib/utils.js';
+	import { cn } from '$lib/utils.js';
 	import MinusIcon from '@lucide/svelte/icons/minus';
 
 	let {
@@ -16,12 +16,12 @@
 	bind:this={ref}
 	data-slot="input-otp-separator"
 	role="separator"
-	class={cn("[&_svg:not([class*='size-'])]:size-4 flex items-center", className)}
+	class={cn("flex items-center [&_svg:not([class*='size-'])]:size-4", className)}
 	{...restProps}
 >
 	{#if children}
 		{@render children?.()}
 	{:else}
-		<MinusIcon  />
+		<MinusIcon />
 	{/if}
 </div>

--- a/src/lib/components/ui/input-otp/input-otp-slot.svelte
+++ b/src/lib/components/ui/input-otp/input-otp-slot.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { PinInput as InputOTPPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		cell,
+		class: className,
+		...restProps
+	}: InputOTPPrimitive.CellProps = $props();
+</script>
+
+<InputOTPPrimitive.Cell
+	{cell}
+	bind:ref
+	data-slot="input-otp-slot"
+	class={cn(
+		"bg-input/20 dark:bg-input/30 border-input data-[active=true]:border-ring data-[active=true]:ring-ring/30 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive size-7 border-y border-r text-xs/relaxed transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:ring-2 relative flex items-center justify-center data-[active=true]:z-10",
+		className
+	)}
+	{...restProps}
+>
+	{cell.char}
+	{#if cell.hasFakeCaret}
+		<div
+			class="cn-input-otp-caret pointer-events-none absolute inset-0 flex items-center justify-center"
+		>
+			<div class="animate-caret-blink bg-foreground h-4 w-px duration-1000 bg-foreground h-4 w-px"></div>
+		</div>
+	{/if}
+</InputOTPPrimitive.Cell>

--- a/src/lib/components/ui/input-otp/input-otp-slot.svelte
+++ b/src/lib/components/ui/input-otp/input-otp-slot.svelte
@@ -25,7 +25,7 @@
 		<div
 			class="cn-input-otp-caret pointer-events-none absolute inset-0 flex items-center justify-center"
 		>
-			<div class="animate-caret-blink bg-foreground h-4 w-px duration-1000 bg-foreground h-4 w-px"></div>
+			<div class="animate-caret-blink bg-foreground h-4 w-px duration-1000"></div>
 		</div>
 	{/if}
 </InputOTPPrimitive.Cell>

--- a/src/lib/components/ui/input-otp/input-otp-slot.svelte
+++ b/src/lib/components/ui/input-otp/input-otp-slot.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { PinInput as InputOTPPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { PinInput as InputOTPPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -15,7 +15,7 @@
 	bind:ref
 	data-slot="input-otp-slot"
 	class={cn(
-		"bg-input/20 dark:bg-input/30 border-input data-[active=true]:border-ring data-[active=true]:ring-ring/30 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive size-7 border-y border-r text-xs/relaxed transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:ring-2 relative flex items-center justify-center data-[active=true]:z-10",
+		'relative flex size-7 items-center justify-center border-y border-r border-input bg-input/20 text-xs/relaxed transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-2 data-[active=true]:ring-ring/30 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 dark:bg-input/30 dark:data-[active=true]:aria-invalid:ring-destructive/40',
 		className
 	)}
 	{...restProps}
@@ -25,7 +25,7 @@
 		<div
 			class="cn-input-otp-caret pointer-events-none absolute inset-0 flex items-center justify-center"
 		>
-			<div class="animate-caret-blink bg-foreground h-4 w-px duration-1000"></div>
+			<div class="h-4 w-px animate-caret-blink bg-foreground duration-1000"></div>
 		</div>
 	{/if}
 </InputOTPPrimitive.Cell>

--- a/src/lib/components/ui/input-otp/input-otp.svelte
+++ b/src/lib/components/ui/input-otp/input-otp.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { PinInput as InputOTPPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		value = $bindable(""),
+		...restProps
+	}: InputOTPPrimitive.RootProps = $props();
+</script>
+
+<InputOTPPrimitive.Root
+	bind:ref
+	bind:value
+	data-slot="input-otp"
+	spellcheck={false}
+	class={cn(
+		"cn-input-otp-input gap-2 flex items-center disabled:cursor-not-allowed has-disabled:opacity-50",
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/input-otp/input-otp.svelte
+++ b/src/lib/components/ui/input-otp/input-otp.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { PinInput as InputOTPPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { PinInput as InputOTPPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
 		class: className,
-		value = $bindable(""),
+		value = $bindable(''),
 		...restProps
 	}: InputOTPPrimitive.RootProps = $props();
 </script>
@@ -16,7 +16,7 @@
 	data-slot="input-otp"
 	spellcheck={false}
 	class={cn(
-		"cn-input-otp-input gap-2 flex items-center disabled:cursor-not-allowed has-disabled:opacity-50",
+		'cn-input-otp-input flex items-center gap-2 disabled:cursor-not-allowed has-disabled:opacity-50',
 		className
 	)}
 	{...restProps}

--- a/src/routes/(auth)/sign-in/+page.svelte
+++ b/src/routes/(auth)/sign-in/+page.svelte
@@ -8,11 +8,7 @@
 	import { REGEXP_ONLY_DIGITS } from 'bits-ui';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import {
-		InputOTP,
-		InputOTPGroup,
-		InputOTPSlot
-	} from '$lib/components/ui/input-otp';
+	import { InputOTP, InputOTPGroup, InputOTPSlot } from '$lib/components/ui/input-otp';
 
 	const inputClass =
 		'h-14 rounded-xl border-(--m-border-strong) bg-(--m-elevated) px-4 text-sm text-foreground shadow-none transition-[border-color,box-shadow] placeholder:text-(--m-text-3) focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/25 sm:px-5 md:text-sm';

--- a/src/routes/(auth)/sign-in/+page.svelte
+++ b/src/routes/(auth)/sign-in/+page.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
+	import { RefreshCw } from '@lucide/svelte';
 	import { useClerkContext } from 'svelte-clerk';
 	import { getClerkErrorMessage, getSafePostAuthRedirectHref } from '$lib/auth/clerk-helpers';
 	import AuthPageShell from '$lib/components/marketing/auth/AuthPageShell.svelte';
+	import { REGEXP_ONLY_DIGITS } from 'bits-ui';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import {
+		InputOTP,
+		InputOTPGroup,
+		InputOTPSlot
+	} from '$lib/components/ui/input-otp';
 
 	const inputClass =
 		'h-14 rounded-xl border-(--m-border-strong) bg-(--m-elevated) px-4 text-sm text-foreground shadow-none transition-[border-color,box-shadow] placeholder:text-(--m-text-3) focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/25 sm:px-5 md:text-sm';
@@ -34,12 +41,26 @@
 	let primarySecondFactorStrategy = $state<Exclude<SecondFactorStrategy, 'backup_code'> | null>(
 		null
 	);
-	let secondFactorMessage = $state('');
 	let secondFactorEmailAddressId = $state<string | null>(null);
 	let secondFactorPhoneNumberId = $state<string | null>(null);
 	let backupCodeAvailable = $state(false);
 	const redirectTo = $derived(page.url.searchParams.get('redirectTo'));
 	const postAuthRedirectUrl = $derived(getSafePostAuthRedirectHref(redirectTo));
+
+	const authPageTitle = $derived(
+		isAwaitingSecondFactor && secondFactorStrategy
+			? secondFactorStrategy === 'email_code'
+				? 'Check your email'
+				: secondFactorStrategy === 'phone_code'
+					? 'Check your phone'
+					: secondFactorStrategy === 'totp'
+						? 'Two-step verification'
+						: 'Backup code'
+			: 'Welcome back'
+	);
+	const authPageDescription = $derived(
+		isAwaitingSecondFactor ? undefined : 'Sign in to your Waiver Director account.'
+	);
 
 	function getSignInResource() {
 		return clerk.client?.signIn ?? null;
@@ -58,7 +79,6 @@
 		isAwaitingSecondFactor = false;
 		secondFactorStrategy = null;
 		primarySecondFactorStrategy = null;
-		secondFactorMessage = '';
 		secondFactorEmailAddressId = null;
 		secondFactorPhoneNumberId = null;
 		backupCodeAvailable = false;
@@ -68,27 +88,16 @@
 		signIn: NonNullable<ReturnType<typeof getSignInResource>>,
 		strategy: SecondFactorStrategy
 	) {
-		switch (strategy) {
-			case 'email_code':
-				await signIn.prepareSecondFactor({
-					strategy,
-					...(secondFactorEmailAddressId ? { emailAddressId: secondFactorEmailAddressId } : {})
-				});
-				secondFactorMessage = 'We sent a verification code to your email.';
-				break;
-			case 'phone_code':
-				await signIn.prepareSecondFactor({
-					strategy,
-					...(secondFactorPhoneNumberId ? { phoneNumberId: secondFactorPhoneNumberId } : {})
-				});
-				secondFactorMessage = 'We sent a verification code to your phone.';
-				break;
-			case 'totp':
-				secondFactorMessage = 'Enter the code from your authenticator app to finish signing in.';
-				break;
-			case 'backup_code':
-				secondFactorMessage = 'Enter one of your backup codes to finish signing in.';
-				break;
+		if (strategy === 'email_code') {
+			await signIn.prepareSecondFactor({
+				strategy,
+				...(secondFactorEmailAddressId ? { emailAddressId: secondFactorEmailAddressId } : {})
+			});
+		} else if (strategy === 'phone_code') {
+			await signIn.prepareSecondFactor({
+				strategy,
+				...(secondFactorPhoneNumberId ? { phoneNumberId: secondFactorPhoneNumberId } : {})
+			});
 		}
 
 		secondFactorStrategy = strategy;
@@ -229,9 +238,7 @@
 		}
 	}
 
-	async function handleSecondFactorSubmit(event: SubmitEvent) {
-		event.preventDefault();
-
+	async function attemptSecondFactor() {
 		const signIn = getSignInResource();
 		if (!clerk.isLoaded || !signIn || !secondFactorStrategy) {
 			submitError = 'Authentication is still loading. Please try again.';
@@ -258,12 +265,19 @@
 				return;
 			}
 
+			verificationCode = '';
 			submitError = 'Verification is not complete yet. Please check the code and try again.';
 		} catch (error) {
 			submitError = getClerkErrorMessage(error, 'Unable to verify your sign-in right now.');
+			verificationCode = '';
 		} finally {
 			isSubmitting = false;
 		}
+	}
+
+	async function handleSecondFactorSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		await attemptSecondFactor();
 	}
 
 	async function resendSecondFactorCode() {
@@ -337,46 +351,88 @@
 	<meta name="description" content="Sign in to Waiver Director account." />
 </svelte:head>
 
-<AuthPageShell
-	title="Welcome back"
-	description="Sign in to your Waiver Director account."
-	width="narrow"
->
+<AuthPageShell title={authPageTitle} description={authPageDescription} width="narrow">
 	{#if isAwaitingSecondFactor}
-		<form class="space-y-4" method="post" onsubmit={handleSecondFactorSubmit}>
-			<div class="rounded-xl border border-(--m-border-soft) bg-(--m-elevated) px-4 py-3">
-				<p class="text-sm font-medium">Verify your account</p>
-				<p class="mt-1 text-sm text-muted-foreground">{secondFactorMessage}</p>
-			</div>
+		<div class="mb-8">
+			{#if secondFactorStrategy === 'email_code'}
+				<p class="text-sm leading-relaxed text-muted-foreground sm:text-base">
+					Enter the 6-digit code sent to <strong class="font-semibold text-foreground"
+						>{email.trim()}</strong
+					>.
+				</p>
+			{:else if secondFactorStrategy === 'phone_code'}
+				<p class="text-sm leading-relaxed text-muted-foreground sm:text-base">
+					Enter the 6-digit code sent to your phone.
+				</p>
+			{:else if secondFactorStrategy === 'totp'}
+				<p class="text-sm leading-relaxed text-muted-foreground sm:text-base">
+					Enter the 6-digit code from your authenticator app.
+				</p>
+			{:else if secondFactorStrategy === 'backup_code'}
+				<p class="text-sm leading-relaxed text-muted-foreground sm:text-base">
+					Enter one of your backup codes to finish signing in.
+				</p>
+			{/if}
+		</div>
 
-			<Input
-				id="sign-in-verification-code"
-				name="code"
-				type="text"
-				inputmode="numeric"
-				autocomplete="one-time-code"
-				placeholder={secondFactorStrategy === 'backup_code' ? 'Backup code' : 'Verification code'}
-				aria-label={secondFactorStrategy === 'backup_code' ? 'Backup code' : 'Verification code'}
-				class={inputClass}
-				bind:value={verificationCode}
-			/>
+		<form class="space-y-4" method="post" onsubmit={handleSecondFactorSubmit}>
+			<div>
+				<div class="mb-3 flex items-center justify-between">
+					<label for="sign-in-verification-code" class="text-sm font-medium">
+						{secondFactorStrategy === 'backup_code' ? 'Backup code' : 'Verification code'}
+					</label>
+					{#if secondFactorStrategy === 'email_code' || secondFactorStrategy === 'phone_code'}
+						<Button
+							type="button"
+							variant="outline"
+							class="h-8 gap-1.5 rounded-lg border-(--m-border-strong) px-3 text-xs font-medium shadow-none"
+							disabled={isSubmitting}
+							onclick={resendSecondFactorCode}
+						>
+							<RefreshCw size={12} />
+							Resend code
+						</Button>
+					{/if}
+				</div>
+
+				{#if secondFactorStrategy !== 'backup_code'}
+					<InputOTP
+						maxlength={6}
+						id="sign-in-verification-code"
+						bind:value={verificationCode}
+						pattern={REGEXP_ONLY_DIGITS}
+						onComplete={attemptSecondFactor}
+						class="w-full"
+					>
+						{#snippet children({ cells })}
+							<InputOTPGroup
+								class="w-full *:data-[slot=input-otp-slot]:h-14 *:data-[slot=input-otp-slot]:flex-1 *:data-[slot=input-otp-slot]:text-xl"
+							>
+								{#each cells as cell, i (i)}
+									<InputOTPSlot {cell} />
+								{/each}
+							</InputOTPGroup>
+						{/snippet}
+					</InputOTP>
+				{:else}
+					<Input
+						id="sign-in-verification-code"
+						name="code"
+						type="text"
+						inputmode="numeric"
+						autocomplete="one-time-code"
+						placeholder="Backup code"
+						aria-label="Backup code"
+						class={inputClass}
+						bind:value={verificationCode}
+					/>
+				{/if}
+			</div>
 
 			<div class="space-y-3 pt-1">
 				<Button type="submit" class={submitButtonClass} disabled={isSubmitting}>
 					{isSubmitting ? 'Verifying...' : 'Verify and continue'}
 				</Button>
-
-				{#if secondFactorStrategy === 'email_code' || secondFactorStrategy === 'phone_code'}
-					<Button
-						type="button"
-						variant="outline"
-						class={secondaryButtonClass}
-						disabled={isSubmitting}
-						onclick={resendSecondFactorCode}
-					>
-						Resend code
-					</Button>
-				{/if}
 
 				{#if backupCodeAvailable && secondFactorStrategy !== 'backup_code'}
 					<Button

--- a/src/routes/(auth)/sign-in/+page.svelte
+++ b/src/routes/(auth)/sign-in/+page.svelte
@@ -394,7 +394,7 @@
 				{#if secondFactorStrategy !== 'backup_code'}
 					<InputOTP
 						maxlength={6}
-						id="sign-in-verification-code"
+						inputId="sign-in-verification-code"
 						bind:value={verificationCode}
 						pattern={REGEXP_ONLY_DIGITS}
 						onComplete={attemptSecondFactor}

--- a/src/routes/(auth)/sign-up/+page.svelte
+++ b/src/routes/(auth)/sign-up/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
-	import { ChartLine, FileText, Link2, Mail, ShieldCheck } from '@lucide/svelte';
+	import { ChartLine, FileText, Link2, Mail, RefreshCw, ShieldCheck } from '@lucide/svelte';
+	import { REGEXP_ONLY_DIGITS } from 'bits-ui';
 	import { useClerkContext } from 'svelte-clerk';
 
 	import { getClerkErrorMessage, getSafePostAuthRedirectHref } from '$lib/auth/clerk-helpers';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import { InputOTP, InputOTPGroup, InputOTPSlot } from '$lib/components/ui/input-otp';
 
 	const inputClass =
 		'h-14 rounded-xl border-(--m-border-strong) bg-(--m-elevated) px-4 text-sm text-foreground shadow-none transition-[border-color,box-shadow] placeholder:text-(--m-text-3) focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/25 sm:px-5 md:text-sm';
@@ -141,7 +143,6 @@
 			});
 
 			isAwaitingVerification = true;
-			submitMessage = `We sent a verification code to ${email.trim()}.`;
 		} catch (error) {
 			submitError = getClerkErrorMessage(error, 'Unable to create your account right now.');
 		} finally {
@@ -149,9 +150,7 @@
 		}
 	}
 
-	async function handleVerificationSubmit(event: SubmitEvent) {
-		event.preventDefault();
-
+	async function attemptVerification() {
 		const signUp = getSignUpResource();
 		if (!clerk.isLoaded || !signUp) {
 			submitError = 'Authentication is still loading. Please try again.';
@@ -176,9 +175,34 @@
 				return;
 			}
 
+			verificationCode = '';
 			submitError = 'Verification is not complete yet. Please check the code and try again.';
 		} catch (error) {
 			submitError = getClerkErrorMessage(error, 'Unable to verify your email right now.');
+			verificationCode = '';
+		} finally {
+			isSubmitting = false;
+		}
+	}
+
+	async function handleVerificationSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		await attemptVerification();
+	}
+
+	async function handleResendCode() {
+		const signUp = getSignUpResource();
+		if (!clerk.isLoaded || !signUp) return;
+
+		isSubmitting = true;
+		submitError = null;
+		submitMessage = null;
+
+		try {
+			await signUp.prepareEmailAddressVerification({ strategy: 'email_code' });
+			submitMessage = 'Verification code resent.';
+		} catch (error) {
+			submitError = getClerkErrorMessage(error, 'Unable to resend code right now.');
 		} finally {
 			isSubmitting = false;
 		}
@@ -287,38 +311,58 @@
 
 			<!-- Right: Form -->
 			<div class="px-9 py-10 sm:px-12 sm:py-12">
-				<div class="mb-8">
-					<h1
-						class="mb-2 font-black tracking-tight"
-						style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.5rem, 4vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
-					>
-						Create your account
-					</h1>
-					<p class="text-sm leading-relaxed text-muted-foreground sm:text-base">
-						The operator account comes first. Workspace setup is a separate step.
-					</p>
-				</div>
-
 				{#if isAwaitingVerification}
-					<form class="space-y-4" onsubmit={handleVerificationSubmit}>
-						<div class="rounded-xl border border-(--m-border-soft) bg-(--m-elevated) px-4 py-3">
-							<p class="text-sm font-medium">Check your email</p>
-							<p class="mt-1 text-sm text-muted-foreground">
-								Enter the verification code sent to {email.trim()} to finish creating your account.
-							</p>
-						</div>
+					<div class="mb-8">
+						<h1
+							class="mb-2 font-black tracking-tight"
+							style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.5rem, 4vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
+						>
+							Check your email
+						</h1>
+						<p class="text-sm leading-relaxed text-muted-foreground sm:text-base">
+							Enter the 6-digit code sent to <strong class="font-semibold text-foreground"
+								>{email.trim()}</strong
+							>.
+						</p>
+					</div>
 
-						<Input
-							id="sign-up-verification-code"
-							name="code"
-							type="text"
-							inputmode="numeric"
-							autocomplete="one-time-code"
-							placeholder="Verification code"
-							aria-label="Verification code"
-							class={inputClass}
+					<form class="space-y-4" onsubmit={handleVerificationSubmit}>
+						<div>
+							<div class="mb-3 flex items-center justify-between">
+								<label for="otp-verification" class="text-sm font-medium">
+									Verification code
+								</label>
+								<Button
+									type="button"
+									variant="outline"
+									class="h-8 gap-1.5 rounded-lg border-(--m-border-strong) px-3 text-xs font-medium shadow-none"
+									disabled={isSubmitting}
+									onclick={handleResendCode}
+								>
+									<RefreshCw size={12} />
+									Resend code
+								</Button>
+							</div>
+
+						<InputOTP
+							maxlength={6}
+							id="otp-verification"
 							bind:value={verificationCode}
-						/>
+							pattern={REGEXP_ONLY_DIGITS}
+							onComplete={attemptVerification}
+							class="w-full"
+						>
+							{#snippet children({ cells })}
+								<InputOTPGroup
+									class="w-full *:data-[slot=input-otp-slot]:h-14 *:data-[slot=input-otp-slot]:flex-1 *:data-[slot=input-otp-slot]:text-xl"
+								>
+									{#each cells as cell, i (i)}
+										<InputOTPSlot {cell} />
+									{/each}
+								</InputOTPGroup>
+							{/snippet}
+						</InputOTP>
+						</div>
 
 						<div class="space-y-3 pt-1">
 							<Button type="submit" class={submitButtonClass} disabled={isSubmitting}>
@@ -356,6 +400,17 @@
 						</div>
 					</form>
 				{:else}
+					<div class="mb-8">
+						<h1
+							class="mb-2 font-black tracking-tight"
+							style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.5rem, 4vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
+						>
+							Create your account
+						</h1>
+						<p class="text-sm leading-relaxed text-muted-foreground sm:text-base">
+							Get early access to Waiver Director.
+						</p>
+					</div>
 					<form class="space-y-4" onsubmit={handleSubmit}>
 						<Input
 							id="sign-up-email"
@@ -443,12 +498,6 @@
 								</svg>
 								Continue with Google
 							</Button>
-
-							{#if submitMessage}
-								<p class="text-center text-sm text-muted-foreground" role="status">
-									{submitMessage}
-								</p>
-							{/if}
 
 							{#if submitError}
 								<p class="text-center text-sm text-destructive" role="status">{submitError}</p>

--- a/src/routes/(auth)/sign-up/+page.svelte
+++ b/src/routes/(auth)/sign-up/+page.svelte
@@ -208,29 +208,6 @@
 		}
 	}
 
-	async function handleVerificationSubmit(event: SubmitEvent) {
-		event.preventDefault();
-		await attemptVerification();
-	}
-
-	async function handleResendCode() {
-		const signUp = getSignUpResource();
-		if (!clerk.isLoaded || !signUp) return;
-
-		isSubmitting = true;
-		submitError = null;
-		submitMessage = null;
-
-		try {
-			await signUp.prepareEmailAddressVerification({ strategy: 'email_code' });
-			submitMessage = 'Verification code resent.';
-		} catch (error) {
-			submitError = getClerkErrorMessage(error, 'Unable to resend code right now.');
-		} finally {
-			isSubmitting = false;
-		}
-	}
-
 	function restartSignUp() {
 		isAwaitingVerification = false;
 		verificationCode = '';
@@ -367,24 +344,24 @@
 								</Button>
 							</div>
 
-						<InputOTP
-							maxlength={6}
-							id="otp-verification"
-							bind:value={verificationCode}
-							pattern={REGEXP_ONLY_DIGITS}
-							onComplete={attemptVerification}
-							class="w-full"
-						>
-							{#snippet children({ cells })}
-								<InputOTPGroup
-									class="w-full *:data-[slot=input-otp-slot]:h-14 *:data-[slot=input-otp-slot]:flex-1 *:data-[slot=input-otp-slot]:text-xl"
-								>
-									{#each cells as cell, i (i)}
-										<InputOTPSlot {cell} />
-									{/each}
-								</InputOTPGroup>
-							{/snippet}
-						</InputOTP>
+							<InputOTP
+								maxlength={6}
+								id="otp-verification"
+								bind:value={verificationCode}
+								pattern={REGEXP_ONLY_DIGITS}
+								onComplete={attemptVerification}
+								class="w-full"
+							>
+								{#snippet children({ cells })}
+									<InputOTPGroup
+										class="w-full *:data-[slot=input-otp-slot]:h-14 *:data-[slot=input-otp-slot]:flex-1 *:data-[slot=input-otp-slot]:text-xl"
+									>
+										{#each cells as cell, i (i)}
+											<InputOTPSlot {cell} />
+										{/each}
+									</InputOTPGroup>
+								{/snippet}
+							</InputOTP>
 						</div>
 
 						<div class="space-y-3 pt-1">

--- a/src/routes/(auth)/sign-up/+page.svelte
+++ b/src/routes/(auth)/sign-up/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
-	import { ChartLine, FileText, Link2, Mail, ShieldCheck } from '@lucide/svelte';
+	import { ChartLine, FileText, Link2, Mail, RefreshCw, ShieldCheck } from '@lucide/svelte';
+	import { REGEXP_ONLY_DIGITS } from 'bits-ui';
 	import { useClerkContext } from 'svelte-clerk';
 
 	import { getClerkErrorMessage, getSafePostAuthRedirectHref } from '$lib/auth/clerk-helpers';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import { InputOTP, InputOTPGroup, InputOTPSlot } from '$lib/components/ui/input-otp';
 
 	const inputClass =
 		'h-14 rounded-xl border-(--m-border-strong) bg-(--m-elevated) px-4 text-sm text-foreground shadow-none transition-[border-color,box-shadow] placeholder:text-(--m-text-3) focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/25 sm:px-5 md:text-sm';
@@ -141,7 +143,6 @@
 			});
 
 			isAwaitingVerification = true;
-			submitMessage = `We sent a verification code to ${email.trim()}.`;
 		} catch (error) {
 			submitError = getClerkErrorMessage(error, 'Unable to create your account right now.');
 		} finally {
@@ -149,9 +150,7 @@
 		}
 	}
 
-	async function handleVerificationSubmit(event: SubmitEvent) {
-		event.preventDefault();
-
+	async function attemptVerification() {
 		const signUp = getSignUpResource();
 		if (!clerk.isLoaded || !signUp) {
 			submitError = 'Authentication is still loading. Please try again.';
@@ -179,6 +178,29 @@
 			submitError = 'Verification is not complete yet. Please check the code and try again.';
 		} catch (error) {
 			submitError = getClerkErrorMessage(error, 'Unable to verify your email right now.');
+		} finally {
+			isSubmitting = false;
+		}
+	}
+
+	async function handleVerificationSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		await attemptVerification();
+	}
+
+	async function handleResendCode() {
+		const signUp = getSignUpResource();
+		if (!clerk.isLoaded || !signUp) return;
+
+		isSubmitting = true;
+		submitError = null;
+		submitMessage = null;
+
+		try {
+			await signUp.prepareEmailAddressVerification({ strategy: 'email_code' });
+			submitMessage = 'Verification code resent.';
+		} catch (error) {
+			submitError = getClerkErrorMessage(error, 'Unable to resend code right now.');
 		} finally {
 			isSubmitting = false;
 		}
@@ -287,38 +309,58 @@
 
 			<!-- Right: Form -->
 			<div class="px-9 py-10 sm:px-12 sm:py-12">
-				<div class="mb-8">
-					<h1
-						class="mb-2 font-black tracking-tight"
-						style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.5rem, 4vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
-					>
-						Create your account
-					</h1>
-					<p class="text-sm leading-relaxed text-muted-foreground sm:text-base">
-						The operator account comes first. Workspace setup is a separate step.
-					</p>
-				</div>
-
 				{#if isAwaitingVerification}
-					<form class="space-y-4" onsubmit={handleVerificationSubmit}>
-						<div class="rounded-xl border border-(--m-border-soft) bg-(--m-elevated) px-4 py-3">
-							<p class="text-sm font-medium">Check your email</p>
-							<p class="mt-1 text-sm text-muted-foreground">
-								Enter the verification code sent to {email.trim()} to finish creating your account.
-							</p>
-						</div>
+					<div class="mb-8">
+						<h1
+							class="mb-2 font-black tracking-tight"
+							style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.5rem, 4vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
+						>
+							Check your email
+						</h1>
+						<p class="text-sm leading-relaxed text-muted-foreground sm:text-base">
+							Enter the 6-digit code sent to <strong class="font-semibold text-foreground"
+								>{email.trim()}</strong
+							>.
+						</p>
+					</div>
 
-						<Input
-							id="sign-up-verification-code"
-							name="code"
-							type="text"
-							inputmode="numeric"
-							autocomplete="one-time-code"
-							placeholder="Verification code"
-							aria-label="Verification code"
-							class={inputClass}
+					<form class="space-y-4" onsubmit={handleVerificationSubmit}>
+						<div>
+							<div class="mb-3 flex items-center justify-between">
+								<label for="otp-verification" class="text-sm font-medium">
+									Verification code
+								</label>
+								<Button
+									type="button"
+									variant="outline"
+									class="h-8 gap-1.5 rounded-lg border-(--m-border-strong) px-3 text-xs font-medium shadow-none"
+									disabled={isSubmitting}
+									onclick={handleResendCode}
+								>
+									<RefreshCw size={12} />
+									Resend code
+								</Button>
+							</div>
+
+						<InputOTP
+							maxlength={6}
+							id="otp-verification"
 							bind:value={verificationCode}
-						/>
+							pattern={REGEXP_ONLY_DIGITS}
+							onComplete={attemptVerification}
+							class="w-full"
+						>
+							{#snippet children({ cells })}
+								<InputOTPGroup
+									class="w-full *:data-[slot=input-otp-slot]:h-14 *:data-[slot=input-otp-slot]:flex-1 *:data-[slot=input-otp-slot]:text-xl"
+								>
+									{#each cells as cell, i (i)}
+										<InputOTPSlot {cell} />
+									{/each}
+								</InputOTPGroup>
+							{/snippet}
+						</InputOTP>
+						</div>
 
 						<div class="space-y-3 pt-1">
 							<Button type="submit" class={submitButtonClass} disabled={isSubmitting}>
@@ -356,6 +398,17 @@
 						</div>
 					</form>
 				{:else}
+					<div class="mb-8">
+						<h1
+							class="mb-2 font-black tracking-tight"
+							style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.5rem, 4vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
+						>
+							Create your account
+						</h1>
+						<p class="text-sm leading-relaxed text-muted-foreground sm:text-base">
+							Get early access to Waiver Director.
+						</p>
+					</div>
 					<form class="space-y-4" onsubmit={handleSubmit}>
 						<Input
 							id="sign-up-email"
@@ -443,12 +496,6 @@
 								</svg>
 								Continue with Google
 							</Button>
-
-							{#if submitMessage}
-								<p class="text-center text-sm text-muted-foreground" role="status">
-									{submitMessage}
-								</p>
-							{/if}
 
 							{#if submitError}
 								<p class="text-center text-sm text-destructive" role="status">{submitError}</p>

--- a/src/routes/(auth)/sign-up/+page.svelte
+++ b/src/routes/(auth)/sign-up/+page.svelte
@@ -346,7 +346,7 @@
 
 							<InputOTP
 								maxlength={6}
-								id="otp-verification"
+								inputId="otp-verification"
 								bind:value={verificationCode}
 								pattern={REGEXP_ONLY_DIGITS}
 								onComplete={attemptVerification}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable OTP input component for digit-based entry.
  * Replaced free-form code inputs with OTP UI in sign-in and sign-up flows.
  * Strategy-aware messaging and labels for verification methods (email/phone/TOTP/backup).
  * Added resend-code action and repositioned resend control for email/phone strategies.
* **UX Improvements**
  * Auto-submit/on-complete OTP behavior and improved verification flow handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->