### PR TITLE
refactor(styles): replace 'Bricolage Grotesque' font with 'var(--m-fo…

### DIFF
--- a/src/lib/components/marketing/MarketingFooter.svelte
+++ b/src/lib/components/marketing/MarketingFooter.svelte
@@ -60,14 +60,13 @@
 				<a href={resolve('/')} class="mb-3 flex items-center gap-2 no-underline">
 					<div
 						class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-[11px] font-black"
-						style="background: var(--primary); color: var(--primary-foreground); font-family: 'Bricolage Grotesque', sans-serif;"
+						style="background: var(--primary); color: var(--primary-foreground); font-family: var(--m-font-display);"
 						aria-hidden="true"
 					>
 						WD
 					</div>
-					<span
-						class="text-[15px] font-bold"
-						style="font-family: 'Bricolage Grotesque', sans-serif;">Waiver Director</span
+					<span class="text-[15px] font-bold" style="font-family: var(--m-font-display);"
+						>Waiver Director</span
 					>
 				</a>
 				<p class="text-[13px]" style="color: var(--m-text-3);">

--- a/src/lib/components/marketing/MarketingNav.svelte
+++ b/src/lib/components/marketing/MarketingNav.svelte
@@ -78,7 +78,7 @@
 				>
 					<div
 						class="mkt-brand-mark flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-[11px] font-black"
-						style="background: var(--primary); color: var(--primary-foreground); font-family: 'Bricolage Grotesque', sans-serif;"
+						style="background: var(--primary); color: var(--primary-foreground); font-family: var(--m-font-display);"
 						aria-hidden="true"
 					>
 						WD
@@ -194,7 +194,7 @@
 	}
 
 	.mkt-brand-wordmark {
-		font-family: 'Bricolage Grotesque', sans-serif;
+		font-family: var(--m-font-display);
 		font-size: 15px;
 	}
 
@@ -304,7 +304,7 @@
 		min-height: 2.75rem;
 		padding: 0.85rem 1rem;
 		border-radius: var(--radius-xl);
-		font-family: 'Bricolage Grotesque', sans-serif;
+		font-family: var(--m-font-display);
 		font-size: clamp(1.1rem, 4vw, 1.3rem);
 		font-weight: 700;
 		letter-spacing: -0.015em;

--- a/src/lib/components/marketing/MarketingPricing.svelte
+++ b/src/lib/components/marketing/MarketingPricing.svelte
@@ -101,7 +101,7 @@
 					</p>
 					<p
 						class="mb-2 leading-none font-black tabular-nums"
-						style="font-family: 'Bricolage Grotesque', sans-serif; font-size: 2.25rem; letter-spacing: -0.03em;"
+						style="font-family: var(--m-font-display); font-size: 2.25rem; letter-spacing: -0.03em;"
 					>
 						{tier.price}
 						<span class="text-[14px] font-medium tracking-normal" style="color: var(--m-text-3);"

--- a/src/lib/components/marketing/auth/AuthPageShell.svelte
+++ b/src/lib/components/marketing/auth/AuthPageShell.svelte
@@ -91,7 +91,7 @@
 	}
 
 	.auth-page__title {
-		font-family: 'Bricolage Grotesque', sans-serif;
+		font-family: var(--m-font-display);
 		font-size: clamp(1.85rem, 5vw, 2.5rem);
 		letter-spacing: -0.03em;
 		line-height: 1.15;

--- a/src/lib/components/marketing/landing-page/LandingPageAnalyticsPreview.svelte
+++ b/src/lib/components/marketing/landing-page/LandingPageAnalyticsPreview.svelte
@@ -110,7 +110,7 @@
 			</p>
 			<h2
 				class="mb-4 max-w-xl font-extrabold tracking-tight"
-				style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
+				style="font-family: var(--m-font-display); font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
 			>
 				Know your completion rate for every session.
 			</h2>

--- a/src/lib/components/marketing/landing-page/LandingPageCta.svelte
+++ b/src/lib/components/marketing/landing-page/LandingPageCta.svelte
@@ -11,10 +11,7 @@
 	style="background: var(--m-bg); border-color: var(--m-border-soft);"
 >
 	<!-- Thin gradient line at top -->
-	<div
-		class="pointer-events-none absolute inset-x-0 top-0 flex justify-center"
-		aria-hidden="true"
-	>
+	<div class="pointer-events-none absolute inset-x-0 top-0 flex justify-center" aria-hidden="true">
 		<div
 			class="h-px w-2/3 max-w-xl"
 			style="background: linear-gradient(90deg, transparent, var(--m-accent-line), transparent);"
@@ -48,13 +45,15 @@
 				Explore features
 			</Button>
 		</div>
-		<p class="mt-5 text-[12px]" style="color: var(--m-text-3);">Free to start · No credit card required</p>
+		<p class="mt-5 text-[12px]" style="color: var(--m-text-3);">
+			Free to start · No credit card required
+		</p>
 	</div>
 </section>
 
 <style>
 	.landing-cta__title {
-		font-family: 'Bricolage Grotesque', sans-serif;
+		font-family: var(--m-font-display);
 		font-size: clamp(2rem, 5vw, 3.5rem);
 		letter-spacing: -0.035em;
 		line-height: 1.06;

--- a/src/lib/components/marketing/landing-page/LandingPageDifferentiator.svelte
+++ b/src/lib/components/marketing/landing-page/LandingPageDifferentiator.svelte
@@ -39,119 +39,116 @@
 >
 	<div class="mx-auto max-w-6xl px-4 sm:px-6">
 		<div use:scrollReveal={{ delay: 0 }}>
+			<p
+				class="mb-3 text-[11px] font-semibold tracking-widest uppercase"
+				style="color: var(--primary);"
+			>
+				The Differentiator
+			</p>
+			<h2
+				class="mb-4 font-extrabold tracking-tight text-balance"
+				style="font-family: var(--m-font-display); font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
+			>
+				One booking. Six email addresses.
+			</h2>
+			<p class="mb-10 max-w-2xl text-[15px] leading-relaxed" style="color: var(--m-text-2);">
+				Most booking systems record only the lead contact. With Waiver Director, every guest who
+				signs is reachable — not just the booker. Optional Mailchimp or Constant Contact sync keeps
+				your existing lists aligned.
+			</p>
+		</div>
+
+		<div class="grid grid-cols-1 gap-4 md:grid-cols-2" use:scrollReveal={{ delay: 80 }}>
+			<!-- Booking system (before) -->
+			<div
+				class="flex h-full min-h-0 flex-col rounded-xl border p-5"
+				style="border-color: var(--m-border-soft); background: var(--m-card);"
+			>
 				<p
-					class="mb-3 text-[11px] font-semibold tracking-widest uppercase"
+					class="mb-4 text-[10px] font-semibold tracking-widest uppercase"
+					style="color: var(--m-text-3);"
+				>
+					Bookeo Booking
+				</p>
+				<!-- Lead contact -->
+				<div
+					class="mb-1.5 flex items-center gap-3 rounded-lg border px-3 py-2"
+					style="border-color: var(--m-border-strong); background: var(--m-elevated);"
+				>
+					<div
+						class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold"
+						style="background: var(--m-accent-dim); color: var(--primary);"
+						aria-hidden="true"
+					>
+						A
+					</div>
+					<div class="min-w-0 flex-1">
+						<p class="text-[12px] font-medium">
+							Alex Martinez <span class="text-[10px] font-normal" style="opacity: 0.55;"
+								>(lead)</span
+							>
+						</p>
+						<p class="text-[11px]" style="color: var(--m-text-3);">alex@email.com</p>
+					</div>
+				</div>
+
+				<!-- Missing rows -->
+				<div aria-hidden="true" class="flex flex-col gap-1.5">
+					{#each missingContactRows as row (row)}
+						<div class="flex items-center gap-3 rounded-lg px-3 py-2 opacity-20">
+							<div
+								class="h-5 w-5 shrink-0 rounded-full"
+								style="background: var(--m-border-strong);"
+							></div>
+							<div class="h-2.5 flex-1 rounded" style="background: var(--m-border-strong);"></div>
+							<div class="h-2.5 w-14 rounded" style="background: var(--m-border-strong);"></div>
+						</div>
+					{/each}
+				</div>
+
+				<p class="mt-auto pt-4 text-[11px] leading-snug" style="color: var(--m-text-3);">
+					5 guests have no contact record in your booking system.
+				</p>
+			</div>
+
+			<!-- Waiver Director (after) -->
+			<div
+				class="relative flex h-full min-h-0 flex-col overflow-hidden rounded-xl border p-5"
+				style="border-color: oklch(0.52 0.22 277 / 35%); background: var(--m-card);"
+			>
+				<!-- Top accent line -->
+				<div
+					class="pointer-events-none absolute inset-x-0 top-0 h-px"
+					style="background: linear-gradient(90deg, transparent, oklch(0.52 0.22 277 / 55%), transparent);"
+					aria-hidden="true"
+				></div>
+
+				<p
+					class="mb-4 text-[10px] font-semibold tracking-widest uppercase"
 					style="color: var(--primary);"
 				>
-					The Differentiator
+					Waiver Director
 				</p>
-				<h2
-					class="mb-4 font-extrabold tracking-tight text-balance"
-					style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
-				>
-					One booking. Six email addresses.
-				</h2>
-				<p class="mb-10 max-w-2xl text-[15px] leading-relaxed" style="color: var(--m-text-2);">
-					Most booking systems record only the lead contact. With Waiver Director, every guest who
-					signs is reachable — not just the booker. Optional Mailchimp or Constant Contact sync keeps
-					your existing lists aligned.
-				</p>
-			</div>
 
-			<div class="grid grid-cols-1 gap-4 md:grid-cols-2" use:scrollReveal={{ delay: 80 }}>
-				<!-- Booking system (before) -->
-				<div
-					class="flex h-full min-h-0 flex-col rounded-xl border p-5"
-					style="border-color: var(--m-border-soft); background: var(--m-card);"
-				>
-					<p
-						class="mb-4 text-[10px] font-semibold tracking-widest uppercase"
-						style="color: var(--m-text-3);"
-					>
-						Bookeo Booking
-					</p>
-					<!-- Lead contact -->
-					<div
-						class="mb-1.5 flex items-center gap-3 rounded-lg border px-3 py-2"
-						style="border-color: var(--m-border-strong); background: var(--m-elevated);"
-					>
-						<div
-							class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold"
-							style="background: var(--m-accent-dim); color: var(--primary);"
-							aria-hidden="true"
-						>
-							A
-						</div>
-						<div class="min-w-0 flex-1">
-							<p class="text-[12px] font-medium">
-								Alex Martinez <span class="text-[10px] font-normal" style="opacity: 0.55;"
-									>(lead)</span
-								>
-							</p>
-							<p class="text-[11px]" style="color: var(--m-text-3);">alex@email.com</p>
-						</div>
-					</div>
-
-					<!-- Missing rows -->
-					<div aria-hidden="true" class="flex flex-col gap-1.5">
-						{#each missingContactRows as row (row)}
-							<div class="flex items-center gap-3 rounded-lg px-3 py-2 opacity-20">
-								<div
-									class="h-5 w-5 shrink-0 rounded-full"
-									style="background: var(--m-border-strong);"
-								></div>
-								<div class="h-2.5 flex-1 rounded" style="background: var(--m-border-strong);"></div>
-								<div
-									class="h-2.5 w-14 rounded"
-									style="background: var(--m-border-strong);"
-								></div>
-							</div>
-						{/each}
-					</div>
-
-					<p class="mt-auto pt-4 text-[11px] leading-snug" style="color: var(--m-text-3);">
-						5 guests have no contact record in your booking system.
-					</p>
+				<div class="flex flex-1 flex-col gap-1.5">
+					{#each capturedGuests as person (person.email)}
+						{@render signedGuestRow(person)}
+					{/each}
 				</div>
 
-				<!-- Waiver Director (after) -->
-				<div
-					class="relative flex h-full min-h-0 flex-col overflow-hidden rounded-xl border p-5"
-					style="border-color: oklch(0.52 0.22 277 / 35%); background: var(--m-card);"
-				>
-					<!-- Top accent line -->
-					<div
-						class="pointer-events-none absolute inset-x-0 top-0 h-px"
-						style="background: linear-gradient(90deg, transparent, oklch(0.52 0.22 277 / 55%), transparent);"
-						aria-hidden="true"
-					></div>
-
-					<p
-						class="mb-4 text-[10px] font-semibold tracking-widest uppercase"
-						style="color: var(--primary);"
-					>
-						Waiver Director
-					</p>
-
-					<div class="flex flex-1 flex-col gap-1.5">
-						{#each capturedGuests as person (person.email)}
-							{@render signedGuestRow(person)}
-						{/each}
-					</div>
-
-					<p class="mt-auto pt-4 text-[11px] leading-snug font-medium" style="color: var(--primary);">
-						6 guests captured → 6 follow-ups queued.
-					</p>
-				</div>
+				<p class="mt-auto pt-4 text-[11px] leading-snug font-medium" style="color: var(--primary);">
+					6 guests captured → 6 follow-ups queued.
+				</p>
 			</div>
+		</div>
 
-			<p
-				class="mt-8 text-center text-[14px] leading-relaxed text-pretty"
-				style="color: var(--m-text-2);"
-				use:scrollReveal={{ delay: 140 }}
-			>
-				Works for any group experience: tours, ziplines, axe throwing, escape rooms, rentals, and
-				more.
-			</p>
+		<p
+			class="mt-8 text-center text-[14px] leading-relaxed text-pretty"
+			style="color: var(--m-text-2);"
+			use:scrollReveal={{ delay: 140 }}
+		>
+			Works for any group experience: tours, ziplines, axe throwing, escape rooms, rentals, and
+			more.
+		</p>
 	</div>
 </section>

--- a/src/lib/components/marketing/landing-page/LandingPageEmailPipeline.svelte
+++ b/src/lib/components/marketing/landing-page/LandingPageEmailPipeline.svelte
@@ -44,7 +44,7 @@
 			</p>
 			<h2
 				class="mb-4 max-w-xl font-extrabold tracking-tight"
-				style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
+				style="font-family: var(--m-font-display); font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
 			>
 				Every signer gets their own follow-up.
 			</h2>

--- a/src/lib/components/marketing/landing-page/LandingPageFeatureTeaser.svelte
+++ b/src/lib/components/marketing/landing-page/LandingPageFeatureTeaser.svelte
@@ -81,7 +81,7 @@
 				</p>
 				<h2
 					class="font-extrabold tracking-tight text-balance"
-					style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
+					style="font-family: var(--m-font-display); font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
 				>
 					Built for the way you actually run sessions.
 				</h2>

--- a/src/lib/components/marketing/landing-page/LandingPageHero.svelte
+++ b/src/lib/components/marketing/landing-page/LandingPageHero.svelte
@@ -111,9 +111,7 @@
 						<p class="mb-1 text-[10px] tracking-widest uppercase" style="color: var(--m-text-3);">
 							Active Session
 						</p>
-						<h2
-							class="landing-hero__session-title mb-0.5 text-[15px] font-bold sm:text-[17px]"
-						>
+						<h2 class="landing-hero__session-title mb-0.5 text-[15px] font-bold sm:text-[17px]">
 							Wilderness Zipline Tour
 						</h2>
 						<p class="text-[12px]" style="color: var(--m-text-3);">Today · 2:00 PM · via Bookeo</p>
@@ -122,22 +120,34 @@
 						class="flex w-full shrink-0 items-center justify-between gap-2 sm:w-auto sm:justify-start sm:gap-4 md:gap-8"
 					>
 						<div class="text-center">
-							<div class="mb-1 text-[18px] leading-none font-bold sm:text-[22px]" style="color: var(--m-green);">
+							<div
+								class="mb-1 text-[18px] leading-none font-bold sm:text-[22px]"
+								style="color: var(--m-green);"
+							>
 								{totalSigned}
 							</div>
-							<div class="text-[10px] tracking-wide uppercase" style="color: var(--m-text-3);">Signed</div>
+							<div class="text-[10px] tracking-wide uppercase" style="color: var(--m-text-3);">
+								Signed
+							</div>
 						</div>
 						<div class="text-center">
 							<div class="mb-1 text-[18px] leading-none font-bold sm:text-[22px]">
 								{totalExpected}
 							</div>
-							<div class="text-[10px] tracking-wide uppercase" style="color: var(--m-text-3);">Expected</div>
+							<div class="text-[10px] tracking-wide uppercase" style="color: var(--m-text-3);">
+								Expected
+							</div>
 						</div>
 						<div class="text-center">
-							<div class="mb-1 text-[18px] leading-none font-bold sm:text-[22px]" style="color: var(--m-amber);">
+							<div
+								class="mb-1 text-[18px] leading-none font-bold sm:text-[22px]"
+								style="color: var(--m-amber);"
+							>
 								{totalPending}
 							</div>
-							<div class="text-[10px] tracking-wide uppercase" style="color: var(--m-text-3);">Pending</div>
+							<div class="text-[10px] tracking-wide uppercase" style="color: var(--m-text-3);">
+								Pending
+							</div>
 						</div>
 					</div>
 				</div>
@@ -210,7 +220,12 @@
 					class="mt-4 flex items-start gap-2.5 rounded-lg border px-4 py-3"
 					style="border-color: var(--m-border-strong); background: var(--m-elevated);"
 				>
-					<Mail size={14} class="mt-0.5 shrink-0" style="color: var(--primary);" aria-hidden="true" />
+					<Mail
+						size={14}
+						class="mt-0.5 shrink-0"
+						style="color: var(--primary);"
+						aria-hidden="true"
+					/>
 					<p class="text-[12px] leading-relaxed" style="color: var(--m-text-2);">
 						<strong>{totalSigned ?? 0} follow-up emails scheduled</strong> — one per guest who signed,
 						not just the lead. Use them for thank-yous, feedback, and review requests.
@@ -234,7 +249,8 @@
 	}
 
 	@keyframes landing-hero-pulse {
-		0%, 100% {
+		0%,
+		100% {
 			opacity: 1;
 			transform: scale(1);
 		}
@@ -245,13 +261,24 @@
 	}
 
 	@keyframes landing-hero-progress {
-		from { width: 0%; }
-		to { width: var(--landing-hero-completion); }
+		from {
+			width: 0%;
+		}
+		to {
+			width: var(--landing-hero-completion);
+		}
 	}
 
 	@keyframes landing-hero-glint {
-		0%, 82%, 90%, 100% { background-position: 0% 50%; }
-		86% { background-position: 100% 50%; }
+		0%,
+		82%,
+		90%,
+		100% {
+			background-position: 0% 50%;
+		}
+		86% {
+			background-position: 100% 50%;
+		}
 	}
 
 	.landing-hero__grid {
@@ -264,20 +291,28 @@
 		animation: landing-hero-entrance 0.55s cubic-bezier(0.16, 1, 0.3, 1) both;
 	}
 
-	.landing-hero__delay-1 { animation-delay: 0.05s; }
-	.landing-hero__delay-2 { animation-delay: 0.15s; }
-	.landing-hero__delay-3 { animation-delay: 0.25s; }
-	.landing-hero__delay-4 { animation-delay: 0.35s; }
+	.landing-hero__delay-1 {
+		animation-delay: 0.05s;
+	}
+	.landing-hero__delay-2 {
+		animation-delay: 0.15s;
+	}
+	.landing-hero__delay-3 {
+		animation-delay: 0.25s;
+	}
+	.landing-hero__delay-4 {
+		animation-delay: 0.35s;
+	}
 
 	h1 {
-		font-family: 'Bricolage Grotesque', sans-serif;
+		font-family: var(--m-font-display);
 		font-size: clamp(44px, 7vw, 82px);
 		letter-spacing: -0.035em;
 		line-height: 1.05;
 	}
 
 	.landing-hero__session-title {
-		font-family: 'Bricolage Grotesque', sans-serif;
+		font-family: var(--m-font-display);
 	}
 
 	.landing-hero__accent {

--- a/src/lib/components/marketing/landing-page/LandingPageHowItWorks.svelte
+++ b/src/lib/components/marketing/landing-page/LandingPageHowItWorks.svelte
@@ -25,7 +25,7 @@
 			</p>
 			<h2
 				class="mb-16 max-w-xl font-extrabold tracking-tight"
-				style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
+				style="font-family: var(--m-font-display); font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
 			>
 				Up and running in three steps.
 			</h2>
@@ -233,7 +233,7 @@
 
 	.landing-how-it-works__step-number {
 		margin-bottom: 0.75rem;
-		font-family: 'Bricolage Grotesque', sans-serif;
+		font-family: var(--m-font-display);
 		font-size: clamp(2.25rem, 10vw, 3.5rem);
 		font-weight: 900;
 		line-height: 1;
@@ -242,7 +242,7 @@
 
 	.landing-how-it-works__step-title {
 		margin-bottom: 0.75rem;
-		font-family: 'Bricolage Grotesque', sans-serif;
+		font-family: var(--m-font-display);
 		font-size: clamp(1.25rem, 3vw, 1.6rem);
 		font-weight: 700;
 		letter-spacing: -0.015em;

--- a/src/lib/components/marketing/landing-page/LandingPageTestimonials.svelte
+++ b/src/lib/components/marketing/landing-page/LandingPageTestimonials.svelte
@@ -49,7 +49,7 @@
 			</p>
 			<h2
 				class="mb-14 max-w-xl font-extrabold tracking-tight"
-				style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
+				style="font-family: var(--m-font-display); font-size: clamp(1.75rem, 3.5vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.06;"
 			>
 				Real results from real sessions.
 			</h2>
@@ -63,12 +63,15 @@
 				>
 					<!-- Opening quote mark -->
 					<span
-						class="select-none text-[1.1rem] font-semibold leading-none"
+						class="text-[1.1rem] leading-none font-semibold select-none"
 						style="color: var(--primary); font-family: Georgia, serif; letter-spacing: -0.01em;"
-						aria-hidden="true"
-					>"</span>
+						aria-hidden="true">"</span
+					>
 
-					<blockquote class="flex-1 text-[14px] leading-relaxed" style="color: oklch(0.82 0.006 286);">
+					<blockquote
+						class="flex-1 text-[14px] leading-relaxed"
+						style="color: oklch(0.82 0.006 286);"
+					>
 						{t.quote}
 					</blockquote>
 
@@ -84,7 +87,7 @@
 							{t.initials}
 						</div>
 						<div class="min-w-0">
-							<p class="text-[13px] font-semibold leading-snug">
+							<p class="text-[13px] leading-snug font-semibold">
 								{t.name}
 								<span class="font-normal" style="color: var(--m-text-3);">· {t.role}</span>
 							</p>

--- a/src/lib/components/marketing/landing-page/MarketingSectionHeading.svelte
+++ b/src/lib/components/marketing/landing-page/MarketingSectionHeading.svelte
@@ -46,7 +46,7 @@
 	}
 
 	.landing-section-heading__title {
-		font-family: 'Bricolage Grotesque', sans-serif;
+		font-family: var(--m-font-display);
 		font-size: clamp(28px, 4vw, 44px);
 		font-weight: 800;
 		letter-spacing: -0.02em;

--- a/src/routes/(app)/app/+layout.svelte
+++ b/src/routes/(app)/app/+layout.svelte
@@ -1,11 +1,23 @@
 <script lang="ts">
+	import { setupConvex } from 'convex-svelte';
+	import { ModeWatcher } from 'mode-watcher';
+	import { ClerkProvider } from 'svelte-clerk';
 	import AppBootstrap from '$lib/components/app/AppBootstrap.svelte';
 	import ConvexClerkBridge from '$lib/components/auth/ConvexClerkBridge.svelte';
+	import { Toaster } from '$lib/components/ui/sonner';
+	import { publicEnv } from '$lib/config/public';
+
+	setupConvex(publicEnv.convexUrl);
+
 	let { children } = $props();
 </script>
 
-<ConvexClerkBridge>
-	<AppBootstrap>
-		{@render children()}
-	</AppBootstrap>
-</ConvexClerkBridge>
+<ModeWatcher defaultMode="dark" />
+<ClerkProvider>
+	<ConvexClerkBridge>
+		<AppBootstrap>
+			{@render children()}
+		</AppBootstrap>
+	</ConvexClerkBridge>
+	<Toaster richColors position="top-right" closeButton />
+</ClerkProvider>

--- a/src/routes/(auth)/+layout.svelte
+++ b/src/routes/(auth)/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { ClerkProvider } from 'svelte-clerk';
 	import MarketingFooter from '$lib/components/marketing/MarketingFooter.svelte';
 	import MarketingNav from '$lib/components/marketing/MarketingNav.svelte';
 
@@ -16,19 +17,21 @@
 	/>
 </svelte:head>
 
-<div class="mkt flex min-h-screen flex-col">
-	<a
-		href="#auth-main"
-		class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-100 focus:rounded-lg focus:px-4 focus:py-2.5 focus:text-sm focus:font-semibold focus:ring-2 focus:ring-offset-2 focus:ring-offset-[oklch(0.09_0.006_286)] focus:outline-none"
-		style="--tw-ring-color: var(--primary); background: var(--primary); color: var(--primary-foreground);"
-	>
-		Skip to main content
-	</a>
-	<MarketingNav />
-	<div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden">
-		<main id="auth-main" class="flex flex-1 flex-col pt-(--mkt-nav-offset)" tabindex="-1">
-			{@render children()}
-		</main>
-		<MarketingFooter />
+<ClerkProvider>
+	<div class="mkt flex min-h-screen flex-col">
+		<a
+			href="#auth-main"
+			class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-100 focus:rounded-lg focus:px-4 focus:py-2.5 focus:text-sm focus:font-semibold focus:ring-2 focus:ring-offset-2 focus:ring-offset-[oklch(0.09_0.006_286)] focus:outline-none"
+			style="--tw-ring-color: var(--primary); background: var(--primary); color: var(--primary-foreground);"
+		>
+			Skip to main content
+		</a>
+		<MarketingNav />
+		<div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden">
+			<main id="auth-main" class="flex flex-1 flex-col pt-(--mkt-nav-offset)" tabindex="-1">
+				{@render children()}
+			</main>
+			<MarketingFooter />
+		</div>
 	</div>
-</div>
+</ClerkProvider>

--- a/src/routes/(auth)/sign-up/+page.svelte
+++ b/src/routes/(auth)/sign-up/+page.svelte
@@ -270,7 +270,7 @@
 					</p>
 					<h2
 						class="signup-panel__heading mb-3 font-black tracking-tight text-balance"
-						style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.5rem, 3.5vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
+						style="font-family: var(--m-font-display); font-size: clamp(1.5rem, 3.5vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
 					>
 						Everything you need to run your business.
 					</h2>
@@ -318,7 +318,7 @@
 					<div class="mb-8">
 						<h1
 							class="mb-2 font-black tracking-tight"
-							style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.5rem, 4vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
+							style="font-family: var(--m-font-display); font-size: clamp(1.5rem, 4vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
 						>
 							Check your email
 						</h1>
@@ -406,7 +406,7 @@
 					<div class="mb-8">
 						<h1
 							class="mb-2 font-black tracking-tight"
-							style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.5rem, 4vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
+							style="font-family: var(--m-font-display); font-size: clamp(1.5rem, 4vw, 2rem); letter-spacing: -0.03em; line-height: 1.15;"
 						>
 							Create your account
 						</h1>

--- a/src/routes/(marketing)/features/+page.svelte
+++ b/src/routes/(marketing)/features/+page.svelte
@@ -136,7 +136,7 @@
 		</p>
 		<h1
 			class="mb-5 max-w-3xl font-extrabold tracking-tight text-balance"
-			style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(2.2rem, 5.5vw, 4rem); letter-spacing: -0.03em; line-height: 1.06;"
+			style="font-family: var(--m-font-display); font-size: clamp(2.2rem, 5.5vw, 4rem); letter-spacing: -0.03em; line-height: 1.06;"
 		>
 			Everything you need to run compliant, automated waivers.
 		</h1>
@@ -161,7 +161,7 @@
 				</p>
 				<h2
 					class="mb-4 font-extrabold tracking-tight text-balance"
-					style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.75rem, 3.5vw, 2.5rem); letter-spacing: -0.025em; line-height: 1.1;"
+					style="font-family: var(--m-font-display); font-size: clamp(1.75rem, 3.5vw, 2.5rem); letter-spacing: -0.025em; line-height: 1.1;"
 				>
 					Build once. Version forever.
 				</h2>
@@ -405,7 +405,7 @@
 				</p>
 				<h2
 					class="mb-4 font-extrabold tracking-tight text-balance"
-					style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.75rem, 3.5vw, 2.5rem); letter-spacing: -0.025em; line-height: 1.1;"
+					style="font-family: var(--m-font-display); font-size: clamp(1.75rem, 3.5vw, 2.5rem); letter-spacing: -0.025em; line-height: 1.1;"
 				>
 					Know your numbers before they arrive.
 				</h2>
@@ -442,7 +442,7 @@
 			</p>
 			<h2
 				class="font-extrabold tracking-tight"
-				style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.75rem, 3.5vw, 2.5rem); letter-spacing: -0.025em; line-height: 1.1;"
+				style="font-family: var(--m-font-display); font-size: clamp(1.75rem, 3.5vw, 2.5rem); letter-spacing: -0.025em; line-height: 1.1;"
 			>
 				Everything else you need.
 			</h2>
@@ -566,7 +566,7 @@
 			</p>
 			<h2
 				class="mb-4 font-extrabold tracking-tight"
-				style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.75rem, 3.5vw, 2.5rem); letter-spacing: -0.025em; line-height: 1.1;"
+				style="font-family: var(--m-font-display); font-size: clamp(1.75rem, 3.5vw, 2.5rem); letter-spacing: -0.025em; line-height: 1.1;"
 			>
 				Connects to your existing stack.
 			</h2>
@@ -627,7 +627,7 @@
 	<div class="mx-auto max-w-3xl text-center" use:scrollReveal={{ delay: 0 }}>
 		<h2
 			class="mb-5 font-extrabold tracking-tight"
-			style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.9rem, 4vw, 3rem); letter-spacing: -0.03em; line-height: 1.1;"
+			style="font-family: var(--m-font-display); font-size: clamp(1.9rem, 4vw, 3rem); letter-spacing: -0.03em; line-height: 1.1;"
 		>
 			Ready to capture every guest?
 		</h2>

--- a/src/routes/(marketing)/marketing-layout.css
+++ b/src/routes/(marketing)/marketing-layout.css
@@ -13,7 +13,7 @@
 
 	/* Background layers — near-black for Linear feel */
 	--m-bg: oklch(0.07 0.005 286);
-	--m-surface: oklch(0.10 0.006 286);
+	--m-surface: oklch(0.1 0.006 286);
 	--m-card: oklch(0.13 0.007 286);
 	--m-elevated: oklch(0.16 0.008 286);
 

--- a/src/routes/(marketing)/pricing/+page.svelte
+++ b/src/routes/(marketing)/pricing/+page.svelte
@@ -79,7 +79,7 @@
 		</p>
 		<h1
 			class="mb-5 font-extrabold tracking-tight text-balance"
-			style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(2.2rem, 5.5vw, 3.75rem); letter-spacing: -0.035em; line-height: 1.06;"
+			style="font-family: var(--m-font-display); font-size: clamp(2.2rem, 5.5vw, 3.75rem); letter-spacing: -0.035em; line-height: 1.06;"
 		>
 			Simple pricing, no surprises.
 		</h1>
@@ -107,7 +107,7 @@
 		</p>
 		<h2
 			class="mb-12 font-extrabold tracking-tight"
-			style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.75rem, 3.5vw, 2.5rem); letter-spacing: -0.025em; line-height: 1.1;"
+			style="font-family: var(--m-font-display); font-size: clamp(1.75rem, 3.5vw, 2.5rem); letter-spacing: -0.025em; line-height: 1.1;"
 		>
 			Frequently asked questions.
 		</h2>
@@ -151,7 +151,7 @@
 	<div class="mx-auto max-w-2xl text-center" use:scrollReveal={{ delay: 0 }}>
 		<h2
 			class="mb-5 font-extrabold tracking-tight"
-			style="font-family: 'Bricolage Grotesque', sans-serif; font-size: clamp(1.9rem, 4vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.1;"
+			style="font-family: var(--m-font-display); font-size: clamp(1.9rem, 4vw, 2.75rem); letter-spacing: -0.03em; line-height: 1.1;"
 		>
 			Start capturing every guest today.
 		</h2>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,23 +1,12 @@
 <script lang="ts">
 	import './layout.css';
 	import favicon from '$lib/assets/favicon.svg';
-	import { ClerkProvider } from 'svelte-clerk';
-	import { setupConvex } from 'convex-svelte';
-	import { ModeWatcher } from 'mode-watcher';
-	import { Toaster } from '$lib/components/ui/sonner';
-	import { publicEnv } from '$lib/config/public';
 
-	// Use one shared Convex client for the app. Protected routes attach auth later via ConvexClerkBridge.
-	setupConvex(publicEnv.convexUrl);
 	let { children } = $props();
 </script>
 
 <svelte:head><link rel="icon" href={favicon} /></svelte:head>
 
-<ModeWatcher defaultMode="dark" />
-<ClerkProvider>
-	<div class="min-h-screen bg-background text-foreground antialiased">
-		{@render children()}
-		<Toaster richColors position="top-right" closeButton />
-	</div>
-</ClerkProvider>
+<div class="min-h-screen bg-background text-foreground antialiased">
+	{@render children()}
+</div>

--- a/src/routes/w/+layout.svelte
+++ b/src/routes/w/+layout.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { setupConvex } from 'convex-svelte';
+	import { Toaster } from '$lib/components/ui/sonner';
+	import { publicEnv } from '$lib/config/public';
+
+	setupConvex(publicEnv.convexUrl);
+
+	let { children } = $props();
+</script>
+
+{@render children()}
+<Toaster richColors position="top-right" closeButton />


### PR DESCRIPTION
…nt-display)' across multiple components for consistency and fix layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added supporting text to call-to-action section: "Free to start · No credit card required."

* **Style**
  * Unified typography styling across marketing pages using centralized font variables for consistent brand presentation.
  * Enhanced dark mode theme initialization and application throughout the app.
  * Refined color values for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->