### PR TITLE
WAI-87 Fix auth marketing contrast

### DIFF
--- a/src/routes/(marketing)/marketing-layout.css
+++ b/src/routes/(marketing)/marketing-layout.css
@@ -51,6 +51,8 @@ body:has(.mkt) {
 	--m-text-1: oklch(0.97 0 0);
 	--m-text-2: oklch(0.65 0.005 286);
 	--m-text-3: oklch(0.6 0.005 286);
+	/* Keep semantic text utilities aligned with this fixed dark theme. */
+	--foreground: var(--m-text-1);
 	--muted-foreground: var(--m-text-3);
 
 	/* Typography */


### PR DESCRIPTION
## Linear

[WAI-87](https://linear.app/waiver-director/issue/WAI-87/fix-continue-with-google-hover-contrast)

## Summary

- define the marketing theme's semantic `--foreground` token as its light primary text token
- restore readable text for the Google sign-in hover state, verification-email address, and auth controls that use `text-foreground`

## Root cause

The auth route renders a fixed dark marketing theme but did not override the app's light-root `--foreground` token. Shared controls applying `text-foreground` therefore rendered near-black text over dark UI surfaces.

## Validation

- `pnpm run check` — passed (0 errors, 0 warnings)
- `pnpm exec prettier --check "src/routes/(marketing)/marketing-layout.css"` — passed
- `pnpm run lint` — blocked by existing Prettier formatting warnings in:
  - `.playwright-mcp/page-2026-05-02T03-23-56-952Z.yml`
  - `.playwright-mcp/page-2026-05-02T03-24-38-692Z.yml`

No deployment, schema, credential, or follow-up configuration changes are required.