### PR TITLE
WAI-65: Implement Constant Contact marketing contact list flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Prerequisites:
 - Clerk application
 - Resend API key for email delivery
 - Bookeo credentials if you are working on booking integrations
-- A registered Mailchimp OAuth app if you are working on marketing-list integrations
+- A registered Mailchimp or Constant Contact OAuth app if you are working on marketing-list
+  integrations
 
 Install dependencies:
 
@@ -113,11 +114,15 @@ BOOKEO_SECRET_KEY=
 BOOKEO_AUTHORIZATION_URL=
 MAILCHIMP_CLIENT_ID=
 MAILCHIMP_CLIENT_SECRET=
+CONSTANT_CONTACT_CLIENT_ID=
+CONSTANT_CONTACT_CLIENT_SECRET=
 INTEGRATION_CREDENTIALS_ENCRYPTION_KEY=
 ```
 
 Register the Mailchimp OAuth callback as `<CONVEX_SITE_URL>/mailchimp/callback`. Keep the client
-secret and credential-encryption key in the Convex runtime environment only.
+secret and credential-encryption key in the Convex runtime environment only. For Constant Contact,
+register `<CONVEX_SITE_URL>/constant-contact/callback` and request the `contact_data` and
+`offline_access` scopes.
 
 Do not commit real secrets or workspace-specific credentials.
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ pnpm exec convex env set --from-file .env.local
 
 Use `--force` only when intentionally replacing existing Convex values.
 
+## Preview Deployments
+
+Vercel preview builds deploy an isolated Convex preview backend and compile its URL into the app.
+The Vercel build command also derives `PUBLIC_APP_URL` from that deployment's `VERCEL_URL`, so
+copied links in a preview stay on that preview rather than pointing at production. See
+[Vercel preview deployments](docs/operations/vercel-preview-deployments.md) for the deployment
+contract and validation steps.
+
 ## Development Scripts
 
 ```sh

--- a/docs/operations/vercel-preview-deployments.md
+++ b/docs/operations/vercel-preview-deployments.md
@@ -1,0 +1,56 @@
+# Vercel Preview Deployments
+
+## Purpose
+
+Every Vercel preview must use an isolated Convex preview backend and must generate application
+links for its own deployment URL. A preview must never send a tester to the production app merely
+because it generated a waiver, booking, or canonical URL.
+
+## Vercel Configuration
+
+Keep Vercel's **Automatically expose System Environment Variables** setting enabled. It supplies
+`VERCEL_URL` for each deployment.
+
+Use this Vercel build command:
+
+```sh
+npx convex deploy --cmd-url-env-var-name PUBLIC_CONVEX_URL --cmd 'PUBLIC_APP_URL="https://$VERCEL_URL" vite build'
+```
+
+The command has two responsibilities:
+
+1. With the Preview-scoped `CONVEX_DEPLOY_KEY`, `convex deploy` creates or updates the Convex
+   preview deployment associated with the Git branch.
+2. It passes that deployment's URL to `vite build` as `PUBLIC_CONVEX_URL` and derives
+   `PUBLIC_APP_URL` from Vercel's deployment-specific URL.
+
+Do not set a shared `PUBLIC_APP_URL` for the Vercel **Preview** environment. That value is
+compiled into the client bundle and would make every preview generate links to the same URL.
+Keep the production `PUBLIC_APP_URL` scoped to **Production** only.
+
+## Environment Boundaries
+
+Vercel build variables and Convex runtime variables are separate.
+
+- `PUBLIC_CONVEX_URL` is set for the Vite build by `convex deploy`; the built preview client uses
+  its matching Convex preview backend.
+- `PUBLIC_APP_URL` is set for the Vite build from `VERCEL_URL`; client-side copied links and
+  marketing canonical URLs remain inside the preview.
+- `APP_URL`, `PUBLIC_APP_URL`, and `SITE_URL` used by Convex actions are runtime values on the
+  Convex deployment. They do not inherit Vercel variables.
+
+External integrations that require a stable callback or redirect URL, including booking and OAuth
+flows, should not be exercised against an ephemeral preview unless a preview-safe callback strategy
+has been configured. Do not point those callbacks at production for MR testing.
+
+## Validate a Preview
+
+After a Git-triggered preview deployment:
+
+1. Confirm the Vercel build is `Ready` and its build logs show the Convex preview deploy succeeded.
+2. Open the preview and sign in with the configured Clerk test environment.
+3. Generate a waiver or booking link and confirm its origin is the preview deployment URL.
+4. Confirm protected app requests reach the preview's Convex deployment, not production.
+
+Preview deployments may be protected by Vercel SSO; use an authorized session or a temporary
+protected-preview share link for the smoke test.

--- a/src/convex/_generated/api.d.ts
+++ b/src/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as app from "../app.js";
 import type * as billing from "../billing.js";
 import type * as bookings from "../bookings.js";
+import type * as constantContact from "../constantContact.js";
 import type * as crons from "../crons.js";
 import type * as customers from "../customers.js";
 import type * as dashboard from "../dashboard.js";
@@ -43,6 +44,7 @@ declare const fullApi: ApiFromModules<{
   app: typeof app;
   billing: typeof billing;
   bookings: typeof bookings;
+  constantContact: typeof constantContact;
   crons: typeof crons;
   customers: typeof customers;
   dashboard: typeof dashboard;

--- a/src/convex/constantContact.ts
+++ b/src/convex/constantContact.ts
@@ -292,14 +292,18 @@ export const completeOAuthCallback = internalAction({
 				sessionId: session.sessionId,
 				status: 'expired'
 			});
-			return { redirectUrl: `${integrationUrl}?constant-contact=expired` };
+			return {
+				redirectUrl: `${integrationUrl}?marketing=constant-contact&marketing-status=expired`
+			};
 		}
 		if (args.error || !args.code) {
 			await ctx.runMutation(internal.marketingIntegrations.markConnectionSession, {
 				sessionId: session.sessionId,
 				status: 'failed'
 			});
-			return { redirectUrl: `${integrationUrl}?constant-contact=denied` };
+			return {
+				redirectUrl: `${integrationUrl}?marketing=constant-contact&marketing-status=denied`
+			};
 		}
 		try {
 			const tokens = await exchangeToken(
@@ -321,7 +325,9 @@ export const completeOAuthCallback = internalAction({
 				sessionId: session.sessionId,
 				status: 'completed'
 			});
-			return { redirectUrl: `${integrationUrl}?constant-contact=connected` };
+			return {
+				redirectUrl: `${integrationUrl}?marketing=constant-contact&marketing-status=authorized`
+			};
 		} catch (error) {
 			console.error('[constant-contact/oauth] unable to complete OAuth callback', {
 				error: providerErrorMessage(error),
@@ -331,7 +337,9 @@ export const completeOAuthCallback = internalAction({
 				sessionId: session.sessionId,
 				status: 'failed'
 			});
-			return { redirectUrl: `${integrationUrl}?constant-contact=callback-error` };
+			return {
+				redirectUrl: `${integrationUrl}?marketing=constant-contact&marketing-status=callback-error`
+			};
 		}
 	}
 });

--- a/src/convex/constantContact.ts
+++ b/src/convex/constantContact.ts
@@ -1,0 +1,423 @@
+'use node';
+
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import { ConvexError, v } from 'convex/values';
+import { internal } from './_generated/api';
+import { action, internalAction, type ActionCtx } from './_generated/server';
+import type { Id } from './_generated/dataModel';
+
+const CONNECTION_STATE_TTL_MS = 30 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 20_000;
+const ACCESS_TOKEN_SKEW_MS = 60_000;
+const MAX_SYNC_ATTEMPTS = 3;
+
+type ConstantContactList = {
+	list_id?: string;
+	name?: string;
+	contact_count?: number;
+};
+
+type ConstantContactConnection = {
+	integrationId: Id<'marketing_integrations'>;
+	encryptedAccessToken: string;
+	encryptedRefreshToken: string | null;
+	accessTokenExpiresAt: number | null;
+};
+
+function requiredEnv(name: string) {
+	const value = process.env[name]?.trim();
+	if (!value) {
+		throw new ConvexError({
+			code: 'invalid_configuration',
+			message: `Missing Convex environment variable: ${name}.`
+		});
+	}
+	return value;
+}
+
+function appUrl() {
+	const configured =
+		process.env.APP_URL?.trim() ||
+		process.env.PUBLIC_APP_URL?.trim() ||
+		process.env.SITE_URL?.trim() ||
+		'http://localhost:5173';
+	try {
+		return new URL(configured).origin;
+	} catch {
+		throw new ConvexError({
+			code: 'invalid_configuration',
+			message: 'APP_URL, PUBLIC_APP_URL, or SITE_URL must be an absolute URL.'
+		});
+	}
+}
+
+function callbackUrl() {
+	const siteUrl = process.env.CONVEX_SITE_URL?.trim() || process.env.PUBLIC_CONVEX_SITE_URL?.trim();
+	if (!siteUrl) {
+		throw new ConvexError({
+			code: 'invalid_configuration',
+			message: 'CONVEX_SITE_URL or PUBLIC_CONVEX_SITE_URL is required for Constant Contact OAuth.'
+		});
+	}
+	return `${new URL(siteUrl).origin}/constant-contact/callback`;
+}
+
+function credentialsKey() {
+	const secret =
+		process.env.INTEGRATION_CREDENTIALS_ENCRYPTION_KEY?.trim() ||
+		process.env.BOOKING_CREDENTIALS_ENCRYPTION_KEY?.trim();
+	if (!secret) {
+		throw new ConvexError({
+			code: 'invalid_configuration',
+			message:
+				'INTEGRATION_CREDENTIALS_ENCRYPTION_KEY is required to store Constant Contact credentials.'
+		});
+	}
+	return createHash('sha256').update(secret).digest();
+}
+
+function encryptToken(value: string) {
+	const iv = randomBytes(12);
+	const cipher = createCipheriv('aes-256-gcm', credentialsKey(), iv);
+	const ciphertext = Buffer.concat([cipher.update(value, 'utf8'), cipher.final()]);
+	const tag = cipher.getAuthTag();
+	return [
+		'v1',
+		iv.toString('base64url'),
+		tag.toString('base64url'),
+		ciphertext.toString('base64url')
+	].join('.');
+}
+
+function decryptToken(value: string) {
+	const [version, ivValue, tagValue, ciphertextValue] = value.split('.');
+	if (version !== 'v1' || !ivValue || !tagValue || !ciphertextValue) {
+		throw new ConvexError({
+			code: 'invalid_state',
+			message: 'Stored Constant Contact credential is invalid.'
+		});
+	}
+	const decipher = createDecipheriv(
+		'aes-256-gcm',
+		credentialsKey(),
+		Buffer.from(ivValue, 'base64url')
+	);
+	decipher.setAuthTag(Buffer.from(tagValue, 'base64url'));
+	return Buffer.concat([
+		decipher.update(Buffer.from(ciphertextValue, 'base64url')),
+		decipher.final()
+	]).toString('utf8');
+}
+
+function connectionState() {
+	return randomBytes(24).toString('base64url');
+}
+
+function providerErrorMessage(error: unknown) {
+	if (error instanceof ConvexError) {
+		const data = error.data as { message?: string };
+		if (typeof data?.message === 'string') return data.message;
+	}
+	if (error instanceof Error) return error.message;
+	return 'Constant Contact request failed.';
+}
+
+async function fetchWithTimeout(input: string, init: RequestInit = {}) {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+	try {
+		return await fetch(input, { ...init, signal: controller.signal });
+	} catch (error) {
+		if (error instanceof Error && error.name === 'AbortError') {
+			throw new ConvexError({
+				code: 'provider_error',
+				message: 'Constant Contact request timed out.'
+			});
+		}
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+async function constantContactFetch(path: string, accessToken: string, init: RequestInit = {}) {
+	const response = await fetchWithTimeout(`https://api.cc.email/v3${path}`, {
+		...init,
+		headers: {
+			Accept: 'application/json',
+			Authorization: `Bearer ${accessToken}`,
+			...(init.body ? { 'Content-Type': 'application/json' } : {}),
+			...init.headers
+		}
+	});
+	if (!response.ok) {
+		let detail = `Constant Contact request failed with ${response.status}.`;
+		try {
+			const body = (await response.json()) as {
+				errors?: Array<{ error_message?: string }>;
+				message?: string;
+			};
+			detail = body.errors?.[0]?.error_message || body.message || detail;
+		} catch {
+			// Keep the status fallback.
+		}
+		throw new ConvexError({
+			code: response.status === 429 ? 'rate_limited' : 'provider_error',
+			message: detail
+		});
+	}
+	return response;
+}
+
+async function exchangeToken(params: URLSearchParams) {
+	const basic = Buffer.from(
+		`${requiredEnv('CONSTANT_CONTACT_CLIENT_ID')}:${requiredEnv('CONSTANT_CONTACT_CLIENT_SECRET')}`
+	).toString('base64');
+	const response = await fetchWithTimeout(
+		'https://authz.constantcontact.com/oauth2/default/v1/token',
+		{
+			method: 'POST',
+			headers: {
+				Authorization: `Basic ${basic}`,
+				'Content-Type': 'application/x-www-form-urlencoded'
+			},
+			body: params
+		}
+	);
+	if (!response.ok) {
+		throw new ConvexError({
+			code: response.status === 429 ? 'rate_limited' : 'provider_error',
+			message: `Constant Contact token exchange failed with ${response.status}.`
+		});
+	}
+	const body = (await response.json()) as {
+		access_token?: string;
+		refresh_token?: string;
+		expires_in?: number;
+	};
+	if (!body.access_token || !body.refresh_token) {
+		throw new ConvexError({
+			code: 'provider_error',
+			message: 'Constant Contact returned incomplete OAuth tokens.'
+		});
+	}
+	return {
+		accessToken: body.access_token,
+		refreshToken: body.refresh_token,
+		expiresAt: Date.now() + (body.expires_in ?? 86_400) * 1000
+	};
+}
+
+async function getFreshAccessToken(ctx: ActionCtx, connection: ConstantContactConnection) {
+	if (
+		connection.accessTokenExpiresAt &&
+		connection.accessTokenExpiresAt > Date.now() + ACCESS_TOKEN_SKEW_MS
+	) {
+		return decryptToken(connection.encryptedAccessToken);
+	}
+	if (!connection.encryptedRefreshToken) {
+		throw new ConvexError({
+			code: 'invalid_state',
+			message: 'Constant Contact refresh token is missing. Reconnect the integration.'
+		});
+	}
+	const refreshed = await exchangeToken(
+		new URLSearchParams({
+			grant_type: 'refresh_token',
+			refresh_token: decryptToken(connection.encryptedRefreshToken)
+		})
+	);
+	await ctx.runMutation(internal.marketingIntegrations.saveRefreshedAccessToken, {
+		integrationId: connection.integrationId,
+		provider: 'constant_contact',
+		encryptedAccessToken: encryptToken(refreshed.accessToken),
+		encryptedRefreshToken: encryptToken(refreshed.refreshToken),
+		accessTokenExpiresAt: refreshed.expiresAt
+	});
+	return refreshed.accessToken;
+}
+
+async function fetchLists(accessToken: string) {
+	const response = await constantContactFetch('/contact_lists?limit=500', accessToken);
+	const body = (await response.json()) as { lists?: ConstantContactList[] };
+	return (body.lists ?? [])
+		.filter((list) => Boolean(list.list_id && list.name))
+		.map((list) => ({ id: list.list_id!, name: list.name!, memberCount: list.contact_count ?? 0 }))
+		.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export const startConnect = action({
+	args: { workspaceId: v.id('workspaces') },
+	returns: v.object({ authorizationUrl: v.string() }),
+	handler: async (ctx, args): Promise<{ authorizationUrl: string }> => {
+		const access: { userId: Id<'users'>; workspaceSlug: string } = await ctx.runQuery(
+			internal.marketingIntegrations.getOwnerAccessForAction,
+			{ workspaceId: args.workspaceId, provider: 'constant_contact' }
+		);
+		const state = connectionState();
+		await ctx.runMutation(internal.marketingIntegrations.createConnectionSession, {
+			workspaceId: args.workspaceId,
+			provider: 'constant_contact',
+			requestedByUserId: access.userId,
+			state,
+			expiresAt: Date.now() + CONNECTION_STATE_TTL_MS
+		});
+		const url = new URL('https://authz.constantcontact.com/oauth2/default/v1/authorize');
+		url.searchParams.set('response_type', 'code');
+		url.searchParams.set('client_id', requiredEnv('CONSTANT_CONTACT_CLIENT_ID'));
+		url.searchParams.set('redirect_uri', callbackUrl());
+		url.searchParams.set('scope', 'contact_data offline_access');
+		url.searchParams.set('state', state);
+		return { authorizationUrl: url.toString() };
+	}
+});
+
+export const completeOAuthCallback = internalAction({
+	args: { state: v.string(), code: v.optional(v.string()), error: v.optional(v.string()) },
+	returns: v.object({ redirectUrl: v.string() }),
+	handler: async (ctx, args): Promise<{ redirectUrl: string }> => {
+		const session: {
+			sessionId: Id<'marketing_connection_sessions'>;
+			workspaceId: Id<'workspaces'>;
+			workspaceSlug: string;
+			expiresAt: number;
+		} | null = await ctx.runQuery(internal.marketingIntegrations.getPendingConnectionSession, {
+			state: args.state,
+			provider: 'constant_contact'
+		});
+		if (!session) return { redirectUrl: `${appUrl()}/app?constant-contact=callback-error` };
+		const integrationUrl = `${appUrl()}/app/${session.workspaceSlug}/integrations`;
+		if (session.expiresAt <= Date.now()) {
+			await ctx.runMutation(internal.marketingIntegrations.markConnectionSession, {
+				sessionId: session.sessionId,
+				status: 'expired'
+			});
+			return { redirectUrl: `${integrationUrl}?constant-contact=expired` };
+		}
+		if (args.error || !args.code) {
+			await ctx.runMutation(internal.marketingIntegrations.markConnectionSession, {
+				sessionId: session.sessionId,
+				status: 'failed'
+			});
+			return { redirectUrl: `${integrationUrl}?constant-contact=denied` };
+		}
+		try {
+			const tokens = await exchangeToken(
+				new URLSearchParams({
+					grant_type: 'authorization_code',
+					code: args.code,
+					redirect_uri: callbackUrl()
+				})
+			);
+			await fetchLists(tokens.accessToken);
+			await ctx.runMutation(internal.marketingIntegrations.saveOAuthConnection, {
+				workspaceId: session.workspaceId,
+				provider: 'constant_contact',
+				encryptedAccessToken: encryptToken(tokens.accessToken),
+				encryptedRefreshToken: encryptToken(tokens.refreshToken),
+				accessTokenExpiresAt: tokens.expiresAt
+			});
+			await ctx.runMutation(internal.marketingIntegrations.markConnectionSession, {
+				sessionId: session.sessionId,
+				status: 'completed'
+			});
+			return { redirectUrl: `${integrationUrl}?constant-contact=connected` };
+		} catch (error) {
+			console.error('[constant-contact/oauth] unable to complete OAuth callback', {
+				error: providerErrorMessage(error),
+				workspaceId: session.workspaceId
+			});
+			await ctx.runMutation(internal.marketingIntegrations.markConnectionSession, {
+				sessionId: session.sessionId,
+				status: 'failed'
+			});
+			return { redirectUrl: `${integrationUrl}?constant-contact=callback-error` };
+		}
+	}
+});
+
+export const listLists = action({
+	args: { workspaceId: v.id('workspaces') },
+	returns: v.array(v.object({ id: v.string(), name: v.string(), memberCount: v.number() })),
+	handler: async (ctx, args) => {
+		const connection = (await ctx.runQuery(
+			internal.marketingIntegrations.getConnectionForOwnerAction,
+			{ workspaceId: args.workspaceId, provider: 'constant_contact' }
+		)) as ConstantContactConnection;
+		return await fetchLists(await getFreshAccessToken(ctx, connection));
+	}
+});
+
+export const chooseList = action({
+	args: { workspaceId: v.id('workspaces'), listId: v.string() },
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const connection = (await ctx.runQuery(
+			internal.marketingIntegrations.getConnectionForOwnerAction,
+			{ workspaceId: args.workspaceId, provider: 'constant_contact' }
+		)) as ConstantContactConnection;
+		const lists = await fetchLists(await getFreshAccessToken(ctx, connection));
+		const list = lists.find((candidate) => candidate.id === args.listId);
+		if (!list) {
+			throw new ConvexError({ code: 'not_found', message: 'Constant Contact list not found.' });
+		}
+		await ctx.runMutation(internal.marketingIntegrations.selectAudience, {
+			workspaceId: args.workspaceId,
+			provider: 'constant_contact',
+			integrationId: connection.integrationId,
+			audienceId: list.id,
+			audienceName: list.name
+		});
+		return null;
+	}
+});
+
+export const syncContact = internalAction({
+	args: { syncId: v.id('marketing_contact_syncs') },
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const sync = (await ctx.runQuery(
+			internal.marketingIntegrations.getContactSyncContext,
+			args
+		)) as
+			| (ConstantContactConnection & {
+					syncId: Id<'marketing_contact_syncs'>;
+					audienceId: string;
+					signerEmail: string;
+					attempts: number;
+					provider: 'constant_contact';
+			  })
+			| null;
+		if (!sync || sync.provider !== 'constant_contact') return null;
+		try {
+			await constantContactFetch('/contacts/sign_up_form', await getFreshAccessToken(ctx, sync), {
+				method: 'POST',
+				body: JSON.stringify({
+					email_address: sync.signerEmail.trim().toLowerCase(),
+					list_memberships: [sync.audienceId]
+				})
+			});
+			await ctx.runMutation(internal.marketingIntegrations.markContactSyncSucceeded, {
+				syncId: sync.syncId,
+				integrationId: sync.integrationId
+			});
+		} catch (error) {
+			const result: { attempts: number } = await ctx.runMutation(
+				internal.marketingIntegrations.markContactSyncFailed,
+				{
+					syncId: sync.syncId,
+					integrationId: sync.integrationId,
+					error: providerErrorMessage(error).slice(0, 500)
+				}
+			);
+			if (result.attempts < MAX_SYNC_ATTEMPTS) {
+				await ctx.scheduler.runAfter(
+					result.attempts * 60_000,
+					internal.constantContact.syncContact,
+					args
+				);
+			}
+		}
+		return null;
+	}
+});

--- a/src/convex/http.ts
+++ b/src/convex/http.ts
@@ -70,6 +70,37 @@ http.route({
 });
 
 http.route({
+	path: '/constant-contact/callback',
+	method: 'GET',
+	handler: httpAction(async (ctx, request) => {
+		const url = new URL(request.url);
+		const state = url.searchParams.get('state') ?? '';
+		const code = url.searchParams.get('code') ?? undefined;
+		const error = url.searchParams.get('error') ?? undefined;
+
+		if (!state) return new Response('Bad request', { status: 400 });
+
+		try {
+			const result: { redirectUrl: string } = await ctx.runAction(
+				internal.constantContact.completeOAuthCallback,
+				{
+					state,
+					...(code ? { code } : {}),
+					...(error ? { error } : {})
+				}
+			);
+			return Response.redirect(result.redirectUrl, 303);
+		} catch (callbackError) {
+			console.error('[constant-contact/callback] unable to complete callback', {
+				error: callbackError,
+				state
+			});
+			return Response.redirect(new URL('/app?constant-contact=callback-error', request.url), 303);
+		}
+	})
+});
+
+http.route({
 	path: '/bookeo/webhook',
 	method: 'POST',
 	handler: httpAction(async (ctx, request) => {

--- a/src/convex/lib/marketing.ts
+++ b/src/convex/lib/marketing.ts
@@ -1,6 +1,9 @@
 import { v } from 'convex/values';
 
-export const marketingProviderValidator = v.literal('mailchimp');
+export const marketingProviderValidator = v.union(
+	v.literal('mailchimp'),
+	v.literal('constant_contact')
+);
 
 export const marketingIntegrationStatusValidator = v.union(
 	v.literal('pending_configuration'),

--- a/src/convex/lib/marketing.ts
+++ b/src/convex/lib/marketing.ts
@@ -13,5 +13,5 @@ export const marketingIntegrationStatusValidator = v.union(
 );
 
 export function marketingConsentLabel(workspaceName: string) {
-	return `Yes, I would like to receive marketing emails from ${workspaceName}.`;
+	return `Yes, I would like to receive marketing emails and promotions from ${workspaceName}.`;
 }

--- a/src/convex/mailchimp.ts
+++ b/src/convex/mailchimp.ts
@@ -246,14 +246,14 @@ export const completeOAuthCallback = internalAction({
 				sessionId: session.sessionId,
 				status: 'expired'
 			});
-			return { redirectUrl: `${integrationUrl}?mailchimp=expired` };
+			return { redirectUrl: `${integrationUrl}?marketing=mailchimp&marketing-status=expired` };
 		}
 		if (args.error || !args.code) {
 			await ctx.runMutation(internal.marketingIntegrations.markConnectionSession, {
 				sessionId: session.sessionId,
 				status: 'failed'
 			});
-			return { redirectUrl: `${integrationUrl}?mailchimp=denied` };
+			return { redirectUrl: `${integrationUrl}?marketing=mailchimp&marketing-status=denied` };
 		}
 
 		try {
@@ -318,7 +318,7 @@ export const completeOAuthCallback = internalAction({
 				sessionId: session.sessionId,
 				status: 'completed'
 			});
-			return { redirectUrl: `${integrationUrl}?mailchimp=connected` };
+			return { redirectUrl: `${integrationUrl}?marketing=mailchimp&marketing-status=authorized` };
 		} catch (error) {
 			console.error('[mailchimp/oauth] unable to complete OAuth callback', {
 				error: providerErrorMessage(error),
@@ -328,7 +328,9 @@ export const completeOAuthCallback = internalAction({
 				sessionId: session.sessionId,
 				status: 'failed'
 			});
-			return { redirectUrl: `${integrationUrl}?mailchimp=callback-error` };
+			return {
+				redirectUrl: `${integrationUrl}?marketing=mailchimp&marketing-status=callback-error`
+			};
 		}
 	}
 });

--- a/src/convex/mailchimp.ts
+++ b/src/convex/mailchimp.ts
@@ -201,11 +201,12 @@ export const startConnect = action({
 	handler: async (ctx, args): Promise<{ authorizationUrl: string }> => {
 		const access: { userId: Id<'users'>; workspaceSlug: string } = await ctx.runQuery(
 			internal.marketingIntegrations.getOwnerAccessForAction,
-			{ workspaceId: args.workspaceId }
+			{ workspaceId: args.workspaceId, provider: 'mailchimp' }
 		);
 		const state = connectionState();
 		await ctx.runMutation(internal.marketingIntegrations.createConnectionSession, {
 			workspaceId: args.workspaceId,
+			provider: 'mailchimp',
 			requestedByUserId: access.userId,
 			state,
 			expiresAt: Date.now() + CONNECTION_STATE_TTL_MS
@@ -234,7 +235,8 @@ export const completeOAuthCallback = internalAction({
 			workspaceSlug: string;
 			expiresAt: number;
 		} | null = await ctx.runQuery(internal.marketingIntegrations.getPendingConnectionSession, {
-			state: args.state
+			state: args.state,
+			provider: 'mailchimp'
 		});
 		if (!session) return { redirectUrl: `${appUrl()}/app?mailchimp=callback-error` };
 
@@ -305,6 +307,7 @@ export const completeOAuthCallback = internalAction({
 			await mailchimpFetch(metadata.dc, tokenBody.access_token, '/ping');
 			await ctx.runMutation(internal.marketingIntegrations.saveOAuthConnection, {
 				workspaceId: session.workspaceId,
+				provider: 'mailchimp',
 				encryptedAccessToken: encryptAccessToken(tokenBody.access_token),
 				serverPrefix: metadata.dc,
 				...(metadata.login?.login_id !== undefined
@@ -337,8 +340,17 @@ export const listAudiences = action({
 		const connection: {
 			integrationId: Id<'marketing_integrations'>;
 			encryptedAccessToken: string;
-			serverPrefix: string;
-		} = await ctx.runQuery(internal.marketingIntegrations.getConnectionForOwnerAction, args);
+			serverPrefix: string | null;
+		} = await ctx.runQuery(internal.marketingIntegrations.getConnectionForOwnerAction, {
+			...args,
+			provider: 'mailchimp'
+		});
+		if (!connection.serverPrefix) {
+			throw new ConvexError({
+				code: 'invalid_state',
+				message: 'Mailchimp server prefix is missing.'
+			});
+		}
 		return await fetchAudiences(
 			connection.serverPrefix,
 			decryptAccessToken(connection.encryptedAccessToken)
@@ -353,10 +365,17 @@ export const chooseAudience = action({
 		const connection: {
 			integrationId: Id<'marketing_integrations'>;
 			encryptedAccessToken: string;
-			serverPrefix: string;
+			serverPrefix: string | null;
 		} = await ctx.runQuery(internal.marketingIntegrations.getConnectionForOwnerAction, {
-			workspaceId: args.workspaceId
+			workspaceId: args.workspaceId,
+			provider: 'mailchimp'
 		});
+		if (!connection.serverPrefix) {
+			throw new ConvexError({
+				code: 'invalid_state',
+				message: 'Mailchimp server prefix is missing.'
+			});
+		}
 		const audiences = await fetchAudiences(
 			connection.serverPrefix,
 			decryptAccessToken(connection.encryptedAccessToken)
@@ -367,6 +386,7 @@ export const chooseAudience = action({
 		}
 		await ctx.runMutation(internal.marketingIntegrations.selectAudience, {
 			workspaceId: args.workspaceId,
+			provider: 'mailchimp',
 			integrationId: connection.integrationId,
 			audienceId: audience.id,
 			audienceName: audience.name
@@ -382,13 +402,20 @@ export const syncContact = internalAction({
 		const sync: {
 			syncId: Id<'marketing_contact_syncs'>;
 			integrationId: Id<'marketing_integrations'>;
+			provider: 'mailchimp' | 'constant_contact';
 			audienceId: string;
 			signerEmail: string;
 			encryptedAccessToken: string;
-			serverPrefix: string;
+			serverPrefix: string | null;
 			attempts: number;
 		} | null = await ctx.runQuery(internal.marketingIntegrations.getContactSyncContext, args);
-		if (!sync) return null;
+		if (!sync || sync.provider !== 'mailchimp') return null;
+		if (!sync.serverPrefix) {
+			throw new ConvexError({
+				code: 'invalid_state',
+				message: 'Mailchimp server prefix is missing.'
+			});
+		}
 
 		try {
 			const email = sync.signerEmail.trim().toLowerCase();

--- a/src/convex/marketingIntegrations.ts
+++ b/src/convex/marketingIntegrations.ts
@@ -14,7 +14,11 @@ import { requireWorkspaceMember, requireWorkspaceOwner } from './lib/waivers';
 const CONNECTION_SESSION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const CONTACT_SYNC_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const CONTACT_SYNC_BATCH_SIZE = 100;
-const DISCONNECTED_CONTACT_SYNC_ERROR = 'Mailchimp was disconnected.';
+const DISCONNECTED_CONTACT_SYNC_ERROR = 'The marketing integration was disconnected.';
+
+function providerName(provider: 'mailchimp' | 'constant_contact') {
+	return provider === 'mailchimp' ? 'Mailchimp' : 'Constant Contact';
+}
 
 async function failQueuedContactSyncBatch(
 	ctx: MutationCtx,
@@ -55,14 +59,14 @@ const marketingIntegrationSummary = v.object({
 });
 
 export const getWorkspaceMarketingIntegration = query({
-	args: { workspaceId: v.id('workspaces') },
+	args: { workspaceId: v.id('workspaces'), provider: marketingProviderValidator },
 	returns: v.union(v.null(), marketingIntegrationSummary),
 	handler: async (ctx, args) => {
 		const { membership } = await requireWorkspaceMember(ctx, args.workspaceId);
 		const integration = await ctx.db
 			.query('marketing_integrations')
 			.withIndex('by_workspaceId_and_provider', (q) =>
-				q.eq('workspaceId', args.workspaceId).eq('provider', 'mailchimp')
+				q.eq('workspaceId', args.workspaceId).eq('provider', args.provider)
 			)
 			.unique();
 
@@ -83,13 +87,32 @@ export const getWorkspaceMarketingIntegration = query({
 });
 
 export const getOwnerAccessForAction = internalQuery({
-	args: { workspaceId: v.id('workspaces') },
+	args: { workspaceId: v.id('workspaces'), provider: marketingProviderValidator },
 	returns: v.object({
 		userId: v.id('users'),
 		workspaceSlug: v.string()
 	}),
 	handler: async (ctx, args) => {
-		const { user } = await requireWorkspaceOwner(ctx, args.workspaceId, 'manage Mailchimp');
+		const { user } = await requireWorkspaceOwner(
+			ctx,
+			args.workspaceId,
+			`manage ${providerName(args.provider)}`
+		);
+		const integrations = await ctx.db
+			.query('marketing_integrations')
+			.withIndex('by_workspaceId', (q) => q.eq('workspaceId', args.workspaceId))
+			.take(2);
+		if (
+			integrations.some(
+				(integration) =>
+					integration.provider !== args.provider && integration.status === 'connected'
+			)
+		) {
+			throw new ConvexError({
+				code: 'conflict',
+				message: 'Disconnect the active marketing integration before connecting another provider.'
+			});
+		}
 		const workspace = await ctx.db.get(args.workspaceId);
 		if (!workspace) {
 			throw new ConvexError({ code: 'not_found', message: 'Workspace not found.' });
@@ -101,6 +124,7 @@ export const getOwnerAccessForAction = internalQuery({
 export const createConnectionSession = internalMutation({
 	args: {
 		workspaceId: v.id('workspaces'),
+		provider: marketingProviderValidator,
 		requestedByUserId: v.id('users'),
 		state: v.string(),
 		expiresAt: v.number()
@@ -109,7 +133,7 @@ export const createConnectionSession = internalMutation({
 	handler: async (ctx, args) => {
 		return await ctx.db.insert('marketing_connection_sessions', {
 			workspaceId: args.workspaceId,
-			provider: 'mailchimp',
+			provider: args.provider,
 			requestedByUserId: args.requestedByUserId,
 			state: args.state,
 			status: 'pending',
@@ -120,7 +144,7 @@ export const createConnectionSession = internalMutation({
 });
 
 export const getPendingConnectionSession = internalQuery({
-	args: { state: v.string() },
+	args: { state: v.string(), provider: marketingProviderValidator },
 	returns: v.union(
 		v.null(),
 		v.object({
@@ -135,7 +159,7 @@ export const getPendingConnectionSession = internalQuery({
 			.query('marketing_connection_sessions')
 			.withIndex('by_state', (q) => q.eq('state', args.state))
 			.unique();
-		if (!session || session.provider !== 'mailchimp' || session.status !== 'pending') return null;
+		if (!session || session.provider !== args.provider || session.status !== 'pending') return null;
 
 		const workspace = await ctx.db.get(session.workspaceId);
 		if (!workspace) return null;
@@ -211,8 +235,11 @@ export const pruneOldContactSyncsCron = internalMutation({
 export const saveOAuthConnection = internalMutation({
 	args: {
 		workspaceId: v.id('workspaces'),
+		provider: marketingProviderValidator,
 		encryptedAccessToken: v.string(),
-		serverPrefix: v.string(),
+		encryptedRefreshToken: v.optional(v.string()),
+		accessTokenExpiresAt: v.optional(v.number()),
+		serverPrefix: v.optional(v.string()),
 		accountId: v.optional(v.string())
 	},
 	returns: v.id('marketing_integrations'),
@@ -220,16 +247,33 @@ export const saveOAuthConnection = internalMutation({
 		const existing = await ctx.db
 			.query('marketing_integrations')
 			.withIndex('by_workspaceId_and_provider', (q) =>
-				q.eq('workspaceId', args.workspaceId).eq('provider', 'mailchimp')
+				q.eq('workspaceId', args.workspaceId).eq('provider', args.provider)
 			)
 			.unique();
+		const otherIntegrations = await ctx.db
+			.query('marketing_integrations')
+			.withIndex('by_workspaceId', (q) => q.eq('workspaceId', args.workspaceId))
+			.take(2);
+		if (
+			otherIntegrations.some(
+				(integration) =>
+					integration.provider !== args.provider && integration.status === 'connected'
+			)
+		) {
+			throw new ConvexError({
+				code: 'conflict',
+				message: 'Disconnect the active marketing integration before connecting another provider.'
+			});
+		}
 		const now = Date.now();
 		const value = {
 			workspaceId: args.workspaceId,
-			provider: 'mailchimp' as const,
+			provider: args.provider,
 			status: 'pending_configuration' as const,
 			encryptedAccessToken: args.encryptedAccessToken,
-			serverPrefix: args.serverPrefix,
+			...(args.encryptedRefreshToken ? { encryptedRefreshToken: args.encryptedRefreshToken } : {}),
+			...(args.accessTokenExpiresAt ? { accessTokenExpiresAt: args.accessTokenExpiresAt } : {}),
+			...(args.serverPrefix ? { serverPrefix: args.serverPrefix } : {}),
 			...(args.accountId ? { accountId: args.accountId } : {}),
 			connectedAt: now,
 			updatedAt: now
@@ -242,32 +286,38 @@ export const saveOAuthConnection = internalMutation({
 });
 
 export const getConnectionForOwnerAction = internalQuery({
-	args: { workspaceId: v.id('workspaces') },
+	args: { workspaceId: v.id('workspaces'), provider: marketingProviderValidator },
 	returns: v.object({
 		integrationId: v.id('marketing_integrations'),
 		encryptedAccessToken: v.string(),
-		serverPrefix: v.string()
+		encryptedRefreshToken: v.union(v.string(), v.null()),
+		accessTokenExpiresAt: v.union(v.number(), v.null()),
+		serverPrefix: v.union(v.string(), v.null())
 	}),
 	handler: async (ctx, args) => {
-		await requireWorkspaceOwner(ctx, args.workspaceId, 'manage Mailchimp');
+		await requireWorkspaceOwner(ctx, args.workspaceId, `manage ${providerName(args.provider)}`);
 		const integration = await ctx.db
 			.query('marketing_integrations')
 			.withIndex('by_workspaceId_and_provider', (q) =>
-				q.eq('workspaceId', args.workspaceId).eq('provider', 'mailchimp')
+				q.eq('workspaceId', args.workspaceId).eq('provider', args.provider)
 			)
 			.unique();
 		if (
 			!integration ||
 			integration.status === 'disconnected' ||
-			!integration.encryptedAccessToken ||
-			!integration.serverPrefix
+			!integration.encryptedAccessToken
 		) {
-			throw new ConvexError({ code: 'not_found', message: 'Mailchimp is not connected.' });
+			throw new ConvexError({
+				code: 'not_found',
+				message: `${providerName(args.provider)} is not connected.`
+			});
 		}
 		return {
 			integrationId: integration._id,
 			encryptedAccessToken: integration.encryptedAccessToken,
-			serverPrefix: integration.serverPrefix
+			encryptedRefreshToken: integration.encryptedRefreshToken ?? null,
+			accessTokenExpiresAt: integration.accessTokenExpiresAt ?? null,
+			serverPrefix: integration.serverPrefix ?? null
 		};
 	}
 });
@@ -275,57 +325,61 @@ export const getConnectionForOwnerAction = internalQuery({
 export const selectAudience = internalMutation({
 	args: {
 		workspaceId: v.id('workspaces'),
+		provider: marketingProviderValidator,
 		integrationId: v.id('marketing_integrations'),
 		audienceId: v.string(),
 		audienceName: v.string()
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		await requireWorkspaceOwner(ctx, args.workspaceId, 'configure Mailchimp');
+		await requireWorkspaceOwner(ctx, args.workspaceId, `configure ${providerName(args.provider)}`);
 		const integration = await ctx.db.get(args.integrationId);
 		if (
 			!integration ||
 			integration.workspaceId !== args.workspaceId ||
-			integration.provider !== 'mailchimp' ||
-			!integration.encryptedAccessToken ||
-			!integration.serverPrefix
+			integration.provider !== args.provider ||
+			!integration.encryptedAccessToken
 		) {
-			throw new ConvexError({ code: 'not_found', message: 'Mailchimp is not connected.' });
+			throw new ConvexError({
+				code: 'not_found',
+				message: `${providerName(args.provider)} is not connected.`
+			});
 		}
 		const now = Date.now();
-		await ctx.db.replace(integration._id, {
-			workspaceId: integration.workspaceId,
-			provider: 'mailchimp',
+		await ctx.db.patch(integration._id, {
 			status: 'connected',
-			encryptedAccessToken: integration.encryptedAccessToken,
-			serverPrefix: integration.serverPrefix,
-			...(integration.accountId ? { accountId: integration.accountId } : {}),
 			audienceId: args.audienceId,
 			audienceName: args.audienceName,
 			connectedAt: integration.connectedAt ?? now,
+			disconnectedAt: undefined,
 			updatedAt: now
 		});
 		return null;
 	}
 });
 
-export const disconnectMailchimp = mutation({
-	args: { workspaceId: v.id('workspaces') },
+export const disconnectMarketingIntegration = mutation({
+	args: { workspaceId: v.id('workspaces'), provider: marketingProviderValidator },
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		await requireWorkspaceOwner(ctx, args.workspaceId, 'disconnect Mailchimp');
+		await requireWorkspaceOwner(ctx, args.workspaceId, `disconnect ${providerName(args.provider)}`);
 		const integration = await ctx.db
 			.query('marketing_integrations')
 			.withIndex('by_workspaceId_and_provider', (q) =>
-				q.eq('workspaceId', args.workspaceId).eq('provider', 'mailchimp')
+				q.eq('workspaceId', args.workspaceId).eq('provider', args.provider)
 			)
 			.unique();
 		if (!integration) return null;
 		const now = Date.now();
-		await ctx.db.replace(integration._id, {
-			workspaceId: integration.workspaceId,
-			provider: 'mailchimp',
+		await ctx.db.patch(integration._id, {
 			status: 'disconnected',
+			encryptedAccessToken: undefined,
+			encryptedRefreshToken: undefined,
+			accessTokenExpiresAt: undefined,
+			serverPrefix: undefined,
+			audienceId: undefined,
+			audienceName: undefined,
+			lastSyncError: undefined,
 			disconnectedAt: now,
 			updatedAt: now
 		});
@@ -378,10 +432,13 @@ export const getContactSyncContext = internalQuery({
 		v.object({
 			syncId: v.id('marketing_contact_syncs'),
 			integrationId: v.id('marketing_integrations'),
+			provider: marketingProviderValidator,
 			audienceId: v.string(),
 			signerEmail: v.string(),
 			encryptedAccessToken: v.string(),
-			serverPrefix: v.string(),
+			encryptedRefreshToken: v.union(v.string(), v.null()),
+			accessTokenExpiresAt: v.union(v.number(), v.null()),
+			serverPrefix: v.union(v.string(), v.null()),
 			attempts: v.number()
 		})
 	),
@@ -399,7 +456,6 @@ export const getContactSyncContext = internalQuery({
 			submission.workspaceId !== sync.workspaceId ||
 			integration.status !== 'connected' ||
 			!integration.encryptedAccessToken ||
-			!integration.serverPrefix ||
 			!submission.marketingConsent
 		) {
 			return null;
@@ -407,12 +463,43 @@ export const getContactSyncContext = internalQuery({
 		return {
 			syncId: sync._id,
 			integrationId: integration._id,
+			provider: integration.provider,
 			audienceId: sync.audienceId,
 			signerEmail: submission.signerEmail,
 			encryptedAccessToken: integration.encryptedAccessToken,
-			serverPrefix: integration.serverPrefix,
+			encryptedRefreshToken: integration.encryptedRefreshToken ?? null,
+			accessTokenExpiresAt: integration.accessTokenExpiresAt ?? null,
+			serverPrefix: integration.serverPrefix ?? null,
 			attempts: sync.attempts
 		};
+	}
+});
+
+export const saveRefreshedAccessToken = internalMutation({
+	args: {
+		integrationId: v.id('marketing_integrations'),
+		provider: v.literal('constant_contact'),
+		encryptedAccessToken: v.string(),
+		encryptedRefreshToken: v.string(),
+		accessTokenExpiresAt: v.number()
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const integration = await ctx.db.get(args.integrationId);
+		if (
+			!integration ||
+			integration.provider !== args.provider ||
+			integration.status === 'disconnected'
+		) {
+			throw new ConvexError({ code: 'not_found', message: 'Constant Contact is not connected.' });
+		}
+		await ctx.db.patch(integration._id, {
+			encryptedAccessToken: args.encryptedAccessToken,
+			encryptedRefreshToken: args.encryptedRefreshToken,
+			accessTokenExpiresAt: args.accessTokenExpiresAt,
+			updatedAt: Date.now()
+		});
+		return null;
 	}
 });
 

--- a/src/convex/marketingIntegrations.ts
+++ b/src/convex/marketingIntegrations.ts
@@ -98,21 +98,6 @@ export const getOwnerAccessForAction = internalQuery({
 			args.workspaceId,
 			`manage ${providerName(args.provider)}`
 		);
-		const integrations = await ctx.db
-			.query('marketing_integrations')
-			.withIndex('by_workspaceId', (q) => q.eq('workspaceId', args.workspaceId))
-			.take(2);
-		if (
-			integrations.some(
-				(integration) =>
-					integration.provider !== args.provider && integration.status === 'connected'
-			)
-		) {
-			throw new ConvexError({
-				code: 'conflict',
-				message: 'Disconnect the active marketing integration before connecting another provider.'
-			});
-		}
 		const workspace = await ctx.db.get(args.workspaceId);
 		if (!workspace) {
 			throw new ConvexError({ code: 'not_found', message: 'Workspace not found.' });
@@ -250,21 +235,6 @@ export const saveOAuthConnection = internalMutation({
 				q.eq('workspaceId', args.workspaceId).eq('provider', args.provider)
 			)
 			.unique();
-		const otherIntegrations = await ctx.db
-			.query('marketing_integrations')
-			.withIndex('by_workspaceId', (q) => q.eq('workspaceId', args.workspaceId))
-			.take(2);
-		if (
-			otherIntegrations.some(
-				(integration) =>
-					integration.provider !== args.provider && integration.status === 'connected'
-			)
-		) {
-			throw new ConvexError({
-				code: 'conflict',
-				message: 'Disconnect the active marketing integration before connecting another provider.'
-			});
-		}
 		const now = Date.now();
 		const value = {
 			workspaceId: args.workspaceId,

--- a/src/convex/schema.ts
+++ b/src/convex/schema.ts
@@ -231,6 +231,15 @@ export default defineSchema({
 		status: v.union(v.literal('submitted')),
 		marketingConsent: v.optional(v.boolean()),
 		marketingConsentLabel: v.optional(v.string()),
+		marketingConsentDestinations: v.optional(
+			v.array(
+				v.object({
+					provider: marketingProviderValidator,
+					audienceId: v.string(),
+					audienceName: v.string()
+				})
+			)
+		),
 		submittedAt: v.number()
 	})
 		.index('by_workspaceId', ['workspaceId'])

--- a/src/convex/schema.ts
+++ b/src/convex/schema.ts
@@ -338,6 +338,8 @@ export default defineSchema({
 		provider: marketingProviderValidator,
 		status: marketingIntegrationStatusValidator,
 		encryptedAccessToken: v.optional(v.string()),
+		encryptedRefreshToken: v.optional(v.string()),
+		accessTokenExpiresAt: v.optional(v.number()),
 		serverPrefix: v.optional(v.string()),
 		accountId: v.optional(v.string()),
 		audienceId: v.optional(v.string()),

--- a/src/convex/waivers.ts
+++ b/src/convex/waivers.ts
@@ -56,7 +56,10 @@ const publicWaiverValue = v.object({
 	fields: v.array(waiverFieldValidator),
 	marketingOptIn: v.union(
 		v.null(),
-		v.object({ provider: v.literal('mailchimp'), label: v.string() })
+		v.object({
+			provider: v.union(v.literal('mailchimp'), v.literal('constant_contact')),
+			label: v.string()
+		})
 	)
 });
 
@@ -70,7 +73,10 @@ const publicBookingWaiverValue = v.object({
 	fields: v.array(waiverFieldValidator),
 	marketingOptIn: v.union(
 		v.null(),
-		v.object({ provider: v.literal('mailchimp'), label: v.string() })
+		v.object({
+			provider: v.union(v.literal('mailchimp'), v.literal('constant_contact')),
+			label: v.string()
+		})
 	),
 	booking: v.object({
 		lookupToken: v.string(),
@@ -88,6 +94,27 @@ async function getWorkspaceWaiverRecord(ctx: FunctionCtx, workspaceId: Id<'works
 		.query('workspace_waivers')
 		.withIndex('by_workspaceId', (q) => q.eq('workspaceId', workspaceId))
 		.unique();
+}
+
+async function getActiveMarketingIntegration(ctx: FunctionCtx, workspaceId: Id<'workspaces'>) {
+	const [mailchimp, constantContact] = await Promise.all([
+		ctx.db
+			.query('marketing_integrations')
+			.withIndex('by_workspaceId_and_provider', (q) =>
+				q.eq('workspaceId', workspaceId).eq('provider', 'mailchimp')
+			)
+			.unique(),
+		ctx.db
+			.query('marketing_integrations')
+			.withIndex('by_workspaceId_and_provider', (q) =>
+				q.eq('workspaceId', workspaceId).eq('provider', 'constant_contact')
+			)
+			.unique()
+	]);
+	for (const integration of [mailchimp, constantContact]) {
+		if (integration?.status === 'connected' && integration.audienceId) return integration;
+	}
+	return null;
 }
 
 async function getNextVersionNumber(ctx: MutationCtx, waiverId: Id<'workspace_waivers'>) {
@@ -441,12 +468,7 @@ export const getPublicWaiverBySlug = query({
 		const [workspace, version, marketingIntegration] = await Promise.all([
 			ctx.db.get(waiver.workspaceId),
 			ctx.db.get(waiver.publishedVersionId),
-			ctx.db
-				.query('marketing_integrations')
-				.withIndex('by_workspaceId_and_provider', (q) =>
-					q.eq('workspaceId', waiver.workspaceId).eq('provider', 'mailchimp')
-				)
-				.unique()
+			getActiveMarketingIntegration(ctx, waiver.workspaceId)
 		]);
 
 		if (
@@ -473,7 +495,10 @@ export const getPublicWaiverBySlug = query({
 			fields: version.fields,
 			marketingOptIn:
 				marketingIntegration?.status === 'connected' && marketingIntegration.audienceId
-					? { provider: 'mailchimp' as const, label: marketingConsentLabel(workspace.name) }
+					? {
+							provider: marketingIntegration.provider,
+							label: marketingConsentLabel(workspace.name)
+						}
 					: null
 		};
 	}
@@ -505,12 +530,7 @@ export const getPublicWaiverForBooking = query({
 		const [workspace, version, marketingIntegration] = await Promise.all([
 			ctx.db.get(waiver.workspaceId),
 			ctx.db.get(waiver.publishedVersionId),
-			ctx.db
-				.query('marketing_integrations')
-				.withIndex('by_workspaceId_and_provider', (q) =>
-					q.eq('workspaceId', waiver.workspaceId).eq('provider', 'mailchimp')
-				)
-				.unique()
+			getActiveMarketingIntegration(ctx, waiver.workspaceId)
 		]);
 		if (
 			!workspace ||
@@ -535,7 +555,10 @@ export const getPublicWaiverForBooking = query({
 			fields: version.fields,
 			marketingOptIn:
 				marketingIntegration?.status === 'connected' && marketingIntegration.audienceId
-					? { provider: 'mailchimp' as const, label: marketingConsentLabel(workspace.name) }
+					? {
+							provider: marketingIntegration.provider,
+							label: marketingConsentLabel(workspace.name)
+						}
 					: null,
 			booking: {
 				lookupToken: booking.lookupToken,
@@ -638,12 +661,7 @@ export const submitPublicWaiver = mutation({
 
 		validateSubmissionAnswers(version, args.answers);
 		const minors = validateMinors(args.minors);
-		const marketingIntegration = await ctx.db
-			.query('marketing_integrations')
-			.withIndex('by_workspaceId_and_provider', (q) =>
-				q.eq('workspaceId', waiver.workspaceId).eq('provider', 'mailchimp')
-			)
-			.unique();
+		const marketingIntegration = await getActiveMarketingIntegration(ctx, waiver.workspaceId);
 		const marketingEnabled = Boolean(
 			marketingIntegration?.status === 'connected' && marketingIntegration.audienceId
 		);
@@ -705,14 +723,18 @@ export const submitPublicWaiver = mutation({
 				workspaceId: waiver.workspaceId,
 				integrationId: marketingIntegration._id,
 				submissionId,
-				provider: 'mailchimp',
+				provider: marketingIntegration.provider,
 				audienceId: marketingIntegration.audienceId,
 				status: 'queued',
 				attempts: 0,
 				createdAt: submittedAt,
 				updatedAt: submittedAt
 			});
-			await ctx.scheduler.runAfter(0, internal.mailchimp.syncContact, { syncId });
+			if (marketingIntegration.provider === 'mailchimp') {
+				await ctx.scheduler.runAfter(0, internal.mailchimp.syncContact, { syncId });
+			} else {
+				await ctx.scheduler.runAfter(0, internal.constantContact.syncContact, { syncId });
+			}
 		}
 
 		await ctx.scheduler.runAfter(0, internal.emails.scheduleFollowUpOnSubmission, {

--- a/src/convex/waivers.ts
+++ b/src/convex/waivers.ts
@@ -9,7 +9,7 @@ import { requireWorkspaceFeature, workspaceHasBillingFeature } from './lib/billi
 import { upsertSignerCustomer } from './lib/customers';
 import { submissionSearchText } from './lib/submissions';
 import { getOwnedWorkspaceLogoUrl } from './lib/workspaces';
-import { marketingConsentLabel } from './lib/marketing';
+import { marketingConsentLabel, marketingProviderValidator } from './lib/marketing';
 import {
 	assertWorkspaceRecord,
 	minorInputValidator,
@@ -57,7 +57,6 @@ const publicWaiverValue = v.object({
 	marketingOptIn: v.union(
 		v.null(),
 		v.object({
-			provider: v.union(v.literal('mailchimp'), v.literal('constant_contact')),
 			label: v.string()
 		})
 	)
@@ -74,7 +73,6 @@ const publicBookingWaiverValue = v.object({
 	marketingOptIn: v.union(
 		v.null(),
 		v.object({
-			provider: v.union(v.literal('mailchimp'), v.literal('constant_contact')),
 			label: v.string()
 		})
 	),
@@ -96,7 +94,7 @@ async function getWorkspaceWaiverRecord(ctx: FunctionCtx, workspaceId: Id<'works
 		.unique();
 }
 
-async function getActiveMarketingIntegration(ctx: FunctionCtx, workspaceId: Id<'workspaces'>) {
+async function getConnectedMarketingIntegrations(ctx: FunctionCtx, workspaceId: Id<'workspaces'>) {
 	const [mailchimp, constantContact] = await Promise.all([
 		ctx.db
 			.query('marketing_integrations')
@@ -111,10 +109,13 @@ async function getActiveMarketingIntegration(ctx: FunctionCtx, workspaceId: Id<'
 			)
 			.unique()
 	]);
+	const integrations: Doc<'marketing_integrations'>[] = [];
 	for (const integration of [mailchimp, constantContact]) {
-		if (integration?.status === 'connected' && integration.audienceId) return integration;
+		if (integration?.status === 'connected' && integration.audienceId) {
+			integrations.push(integration);
+		}
 	}
-	return null;
+	return integrations;
 }
 
 async function getNextVersionNumber(ctx: MutationCtx, waiverId: Id<'workspace_waivers'>) {
@@ -332,7 +333,14 @@ export const getSubmission = query({
 			minors: v.array(v.string()),
 			booking: v.union(v.null(), bookingSnapshotValidator),
 			marketingConsent: v.boolean(),
-			marketingConsentLabel: v.union(v.string(), v.null())
+			marketingConsentLabel: v.union(v.string(), v.null()),
+			marketingConsentDestinations: v.array(
+				v.object({
+					provider: marketingProviderValidator,
+					audienceId: v.string(),
+					audienceName: v.string()
+				})
+			)
 		})
 	),
 	handler: async (ctx, args) => {
@@ -389,7 +397,8 @@ export const getSubmission = query({
 			minors: submission.minors.map((participant) => participant.fullName),
 			booking: submission.bookingSnapshot ?? null,
 			marketingConsent: submission.marketingConsent ?? false,
-			marketingConsentLabel: submission.marketingConsentLabel ?? null
+			marketingConsentLabel: submission.marketingConsentLabel ?? null,
+			marketingConsentDestinations: submission.marketingConsentDestinations ?? []
 		};
 	}
 });
@@ -465,10 +474,10 @@ export const getPublicWaiverBySlug = query({
 			return null;
 		}
 
-		const [workspace, version, marketingIntegration] = await Promise.all([
+		const [workspace, version, marketingIntegrations] = await Promise.all([
 			ctx.db.get(waiver.workspaceId),
 			ctx.db.get(waiver.publishedVersionId),
-			getActiveMarketingIntegration(ctx, waiver.workspaceId)
+			getConnectedMarketingIntegrations(ctx, waiver.workspaceId)
 		]);
 
 		if (
@@ -494,12 +503,7 @@ export const getPublicWaiverBySlug = query({
 			introCopy: version.introCopy,
 			fields: version.fields,
 			marketingOptIn:
-				marketingIntegration?.status === 'connected' && marketingIntegration.audienceId
-					? {
-							provider: marketingIntegration.provider,
-							label: marketingConsentLabel(workspace.name)
-						}
-					: null
+				marketingIntegrations.length > 0 ? { label: marketingConsentLabel(workspace.name) } : null
 		};
 	}
 });
@@ -527,10 +531,10 @@ export const getPublicWaiverForBooking = query({
 			return null;
 		}
 
-		const [workspace, version, marketingIntegration] = await Promise.all([
+		const [workspace, version, marketingIntegrations] = await Promise.all([
 			ctx.db.get(waiver.workspaceId),
 			ctx.db.get(waiver.publishedVersionId),
-			getActiveMarketingIntegration(ctx, waiver.workspaceId)
+			getConnectedMarketingIntegrations(ctx, waiver.workspaceId)
 		]);
 		if (
 			!workspace ||
@@ -554,12 +558,7 @@ export const getPublicWaiverForBooking = query({
 			introCopy: version.introCopy,
 			fields: version.fields,
 			marketingOptIn:
-				marketingIntegration?.status === 'connected' && marketingIntegration.audienceId
-					? {
-							provider: marketingIntegration.provider,
-							label: marketingConsentLabel(workspace.name)
-						}
-					: null,
+				marketingIntegrations.length > 0 ? { label: marketingConsentLabel(workspace.name) } : null,
 			booking: {
 				lookupToken: booking.lookupToken,
 				activityName: booking.activityName,
@@ -661,12 +660,17 @@ export const submitPublicWaiver = mutation({
 
 		validateSubmissionAnswers(version, args.answers);
 		const minors = validateMinors(args.minors);
-		const marketingIntegration = await getActiveMarketingIntegration(ctx, waiver.workspaceId);
-		const marketingEnabled = Boolean(
-			marketingIntegration?.status === 'connected' && marketingIntegration.audienceId
-		);
+		const marketingIntegrations = await getConnectedMarketingIntegrations(ctx, waiver.workspaceId);
+		const marketingEnabled = marketingIntegrations.length > 0;
 		const marketingConsent = marketingEnabled && args.marketingConsent === true;
 		const consentLabel = marketingEnabled ? marketingConsentLabel(workspace.name) : null;
+		const marketingConsentDestinations = marketingConsent
+			? marketingIntegrations.map((integration) => ({
+					provider: integration.provider,
+					audienceId: integration.audienceId!,
+					audienceName: integration.audienceName ?? integration.audienceId!
+				}))
+			: [];
 		let booking: Doc<'bookings'> | null = null;
 		const bookingLookupToken = args.bookingLookupToken;
 		if (bookingLookupToken) {
@@ -706,6 +710,7 @@ export const submitPublicWaiver = mutation({
 			status: 'submitted',
 			marketingConsent,
 			...(consentLabel ? { marketingConsentLabel: consentLabel } : {}),
+			...(marketingEnabled ? { marketingConsentDestinations } : {}),
 			submittedAt
 		});
 		const customerId = await upsertSignerCustomer(ctx, {
@@ -718,7 +723,8 @@ export const submitPublicWaiver = mutation({
 		});
 		await ctx.db.patch(submissionId, { customerId });
 
-		if (marketingConsent && marketingIntegration?.audienceId) {
+		for (const marketingIntegration of marketingIntegrations) {
+			if (!marketingConsent || !marketingIntegration.audienceId) continue;
 			const syncId = await ctx.db.insert('marketing_contact_syncs', {
 				workspaceId: waiver.workspaceId,
 				integrationId: marketingIntegration._id,

--- a/src/lib/components/integrations/MailchimpIntegrationPanel.svelte
+++ b/src/lib/components/integrations/MailchimpIntegrationPanel.svelte
@@ -28,6 +28,8 @@
 		integration: Integration;
 		provider: 'mailchimp' | 'constant_contact';
 		canManage: boolean;
+		requestAudiencePicker?: boolean;
+		onAudiencePickerOpened?: () => void;
 		disconnectDialogOpen?: boolean;
 	}
 
@@ -36,6 +38,8 @@
 		integration,
 		provider,
 		canManage,
+		requestAudiencePicker = false,
+		onAudiencePickerOpened,
 		disconnectDialogOpen = $bindable(false)
 	}: Props = $props();
 	const convex = useConvexClient();
@@ -49,6 +53,7 @@
 	let audienceDialogOpen = $state(false);
 	let audiences = $state<Audience[]>([]);
 	let selectedAudienceId = $state('');
+	let hasHandledAudiencePickerRequest = $state(false);
 
 	function formatTimestamp(timestamp: number | null) {
 		if (!timestamp) return 'Not recorded';
@@ -95,6 +100,23 @@
 			isLoadingAudiences = false;
 		}
 	}
+
+	$effect(() => {
+		if (!requestAudiencePicker) {
+			hasHandledAudiencePickerRequest = false;
+			return;
+		}
+		if (
+			hasHandledAudiencePickerRequest ||
+			integration?.status !== 'pending_configuration' ||
+			!canManage
+		) {
+			return;
+		}
+		hasHandledAudiencePickerRequest = true;
+		void openAudiencePicker();
+		onAudiencePickerOpened?.();
+	});
 
 	async function saveAudience() {
 		if (convex.disabled || !selectedAudienceId || !canManage) return;

--- a/src/lib/components/integrations/MailchimpIntegrationPanel.svelte
+++ b/src/lib/components/integrations/MailchimpIntegrationPanel.svelte
@@ -21,11 +21,12 @@
 	type Integration = FunctionReturnType<
 		typeof api.marketingIntegrations.getWorkspaceMarketingIntegration
 	>;
-	type Audience = FunctionReturnType<typeof api.mailchimp.listAudiences>[number];
+	type Audience = { id: string; name: string; memberCount: number };
 
 	interface Props {
 		workspaceId: Id<'workspaces'>;
 		integration: Integration;
+		provider: 'mailchimp' | 'constant_contact';
 		canManage: boolean;
 		disconnectDialogOpen?: boolean;
 	}
@@ -33,10 +34,13 @@
 	let {
 		workspaceId,
 		integration,
+		provider,
 		canManage,
 		disconnectDialogOpen = $bindable(false)
 	}: Props = $props();
 	const convex = useConvexClient();
+	const providerName = $derived(provider === 'mailchimp' ? 'Mailchimp' : 'Constant Contact');
+	const destinationLabel = $derived(provider === 'mailchimp' ? 'audience' : 'list');
 
 	let isStartingConnect = $state(false);
 	let isLoadingAudiences = $state(false);
@@ -58,10 +62,13 @@
 		if (convex.disabled || !canManage) return;
 		isStartingConnect = true;
 		try {
-			const result = await convex.action(api.mailchimp.startConnect, { workspaceId });
+			const result = await convex.action(
+				provider === 'mailchimp' ? api.mailchimp.startConnect : api.constantContact.startConnect,
+				{ workspaceId }
+			);
 			window.location.href = result.authorizationUrl;
 		} catch (error) {
-			toast.error(getConvexErrorMessage(error, 'Unable to start Mailchimp connection.'));
+			toast.error(getConvexErrorMessage(error, `Unable to start ${providerName} connection.`));
 		} finally {
 			isStartingConnect = false;
 		}
@@ -73,12 +80,17 @@
 		selectedAudienceId = integration?.audienceId ?? '';
 		isLoadingAudiences = true;
 		try {
-			audiences = await convex.action(api.mailchimp.listAudiences, { workspaceId });
+			audiences = await convex.action(
+				provider === 'mailchimp' ? api.mailchimp.listAudiences : api.constantContact.listLists,
+				{ workspaceId }
+			);
 			if (!selectedAudienceId && audiences.length === 1) {
 				selectedAudienceId = audiences[0].id;
 			}
 		} catch (error) {
-			toast.error(getConvexErrorMessage(error, 'Unable to load Mailchimp audiences.'));
+			toast.error(
+				getConvexErrorMessage(error, `Unable to load ${providerName} ${destinationLabel}s.`)
+			);
 		} finally {
 			isLoadingAudiences = false;
 		}
@@ -88,14 +100,25 @@
 		if (convex.disabled || !selectedAudienceId || !canManage) return;
 		isSavingAudience = true;
 		try {
-			await convex.action(api.mailchimp.chooseAudience, {
-				workspaceId,
-				audienceId: selectedAudienceId
-			});
+			if (provider === 'mailchimp') {
+				await convex.action(api.mailchimp.chooseAudience, {
+					workspaceId,
+					audienceId: selectedAudienceId
+				});
+			} else {
+				await convex.action(api.constantContact.chooseList, {
+					workspaceId,
+					listId: selectedAudienceId
+				});
+			}
 			audienceDialogOpen = false;
-			toast.success('Mailchimp audience selected. Marketing opt-in is now available on waivers.');
+			toast.success(
+				`${providerName} ${destinationLabel} selected. Marketing opt-in is now available on waivers.`
+			);
 		} catch (error) {
-			toast.error(getConvexErrorMessage(error, 'Unable to select that Mailchimp audience.'));
+			toast.error(
+				getConvexErrorMessage(error, `Unable to select that ${providerName} ${destinationLabel}.`)
+			);
 		} finally {
 			isSavingAudience = false;
 		}
@@ -105,11 +128,14 @@
 		if (convex.disabled || !canManage) return;
 		isDisconnecting = true;
 		try {
-			await convex.mutation(api.marketingIntegrations.disconnectMailchimp, { workspaceId });
+			await convex.mutation(api.marketingIntegrations.disconnectMarketingIntegration, {
+				workspaceId,
+				provider
+			});
 			disconnectDialogOpen = false;
-			toast.success('Mailchimp disconnected.');
+			toast.success(`${providerName} disconnected.`);
 		} catch (error) {
-			toast.error(getConvexErrorMessage(error, 'Unable to disconnect Mailchimp.'));
+			toast.error(getConvexErrorMessage(error, `Unable to disconnect ${providerName}.`));
 		} finally {
 			isDisconnecting = false;
 		}
@@ -119,7 +145,7 @@
 <Dialog bind:open={audienceDialogOpen}>
 	<DialogContent class="max-w-md">
 		<DialogHeader>
-			<DialogTitle>Choose a Mailchimp audience</DialogTitle>
+			<DialogTitle>Choose a {providerName} {destinationLabel}</DialogTitle>
 			<DialogDescription>
 				Only signers who explicitly opt in will be added to this audience.
 			</DialogDescription>
@@ -132,14 +158,14 @@
 				</p>
 			{:else if audiences.length === 0}
 				<div class="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
-					No audiences were found in this Mailchimp account. Create one in Mailchimp, then try
-					again.
+					No {destinationLabel}s were found in this {providerName} account. Create one in
+					{providerName}, then try again.
 				</div>
 			{:else}
-				<label class="space-y-2 text-sm font-medium" for="mailchimp-audience">
-					<span>Audience</span>
+				<label class="space-y-2 text-sm font-medium" for="marketing-destination">
+					<span>{destinationLabel}</span>
 					<select
-						id="mailchimp-audience"
+						id="marketing-destination"
 						class="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
 						bind:value={selectedAudienceId}
 					>
@@ -160,7 +186,7 @@
 				onclick={saveAudience}
 				disabled={convex.disabled || !selectedAudienceId || isSavingAudience}
 			>
-				{isSavingAudience ? 'Saving...' : 'Use this audience'}
+				{isSavingAudience ? 'Saving...' : `Use this ${destinationLabel}`}
 			</Button>
 		</DialogFooter>
 	</DialogContent>
@@ -169,16 +195,16 @@
 <Dialog bind:open={disconnectDialogOpen}>
 	<DialogContent class="max-w-md">
 		<DialogHeader>
-			<DialogTitle>Disconnect Mailchimp?</DialogTitle>
+			<DialogTitle>Disconnect {providerName}?</DialogTitle>
 			<DialogDescription>
 				The marketing opt-in will be removed from public waivers immediately. Existing signed
-				waivers and Mailchimp contacts are not changed.
+				waivers and {providerName} contacts are not changed.
 			</DialogDescription>
 		</DialogHeader>
 		<DialogFooter>
 			<Button variant="outline" onclick={() => (disconnectDialogOpen = false)}>Cancel</Button>
 			<Button variant="destructive" onclick={disconnect} disabled={isDisconnecting}>
-				{isDisconnecting ? 'Disconnecting...' : 'Disconnect Mailchimp'}
+				{isDisconnecting ? 'Disconnecting...' : `Disconnect ${providerName}`}
 			</Button>
 		</DialogFooter>
 	</DialogContent>
@@ -189,25 +215,27 @@
 		<div class="rounded-lg border border-dashed bg-card/50 p-10 text-center">
 			<p class="text-sm font-medium">Owner access required</p>
 			<p class="mt-1 text-xs text-muted-foreground">
-				Only workspace owners can connect or configure Mailchimp.
+				Only workspace owners can connect or configure {providerName}.
 			</p>
 		</div>
 	{:else if !integration || integration.status === 'disconnected'}
 		<div class="space-y-1">
-			<h3 class="text-sm font-semibold">Connect your Mailchimp account</h3>
+			<h3 class="text-sm font-semibold">Connect your {providerName} account</h3>
 			<p class="text-sm leading-relaxed text-muted-foreground">
-				Authorize Waiver Director, then choose the audience that should receive opted-in signers.
+				Authorize Waiver Director, then choose the {destinationLabel} that should receive opted-in signers.
 			</p>
 		</div>
-		<div class="overflow-hidden border-y" aria-label="Mailchimp connection workflow">
+		<div class="overflow-hidden border-y" aria-label={`${providerName} connection workflow`}>
 			<div class="flex gap-3 border-b py-3">
 				<span
 					class="mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground"
 					>1</span
 				>
 				<div>
-					<p class="text-sm font-medium">Authorize Mailchimp</p>
-					<p class="text-sm text-muted-foreground">Sign in and approve access through Mailchimp.</p>
+					<p class="text-sm font-medium">Authorize {providerName}</p>
+					<p class="text-sm text-muted-foreground">
+						Sign in and approve access through {providerName}.
+					</p>
 				</div>
 			</div>
 			<div class="flex gap-3 py-3">
@@ -216,7 +244,7 @@
 					>2</span
 				>
 				<div>
-					<p class="text-sm font-medium">Choose an audience</p>
+					<p class="text-sm font-medium">Choose a {destinationLabel}</p>
 					<p class="text-sm text-muted-foreground">
 						Opted-in waiver signers are added automatically after submission.
 					</p>
@@ -224,23 +252,23 @@
 			</div>
 		</div>
 		<Button class="self-start" onclick={connect} disabled={convex.disabled || isStartingConnect}>
-			{isStartingConnect ? 'Opening Mailchimp...' : 'Connect Mailchimp'}
+			{isStartingConnect ? `Opening ${providerName}...` : `Connect ${providerName}`}
 			<ExternalLinkIcon class="size-3.5" aria-hidden="true" />
 		</Button>
 	{:else if integration.status === 'pending_configuration'}
 		<div class="rounded-lg border bg-card p-5">
-			<h3 class="text-sm font-semibold">Mailchimp authorized</h3>
+			<h3 class="text-sm font-semibold">{providerName} authorized</h3>
 			<p class="mt-1 text-sm leading-relaxed text-muted-foreground">
-				Choose an audience to enable the optional marketing checkbox on public waivers.
+				Choose a {destinationLabel} to enable the optional marketing checkbox on public waivers.
 			</p>
 			<Button class="mt-4" onclick={openAudiencePicker} disabled={isLoadingAudiences}>
-				{isLoadingAudiences ? 'Loading audiences...' : 'Choose audience'}
+				{isLoadingAudiences ? `Loading ${destinationLabel}s...` : `Choose ${destinationLabel}`}
 			</Button>
 		</div>
 	{:else}
 		<div class="grid gap-3 md:grid-cols-2">
 			<div class="rounded-lg border bg-card p-4">
-				<p class="text-xs font-medium text-muted-foreground">Audience</p>
+				<p class="text-xs font-medium text-muted-foreground">{destinationLabel}</p>
 				<p class="mt-2 text-sm font-semibold">{integration.audienceName ?? 'Not selected'}</p>
 			</div>
 			<div class="rounded-lg border bg-card p-4">
@@ -266,7 +294,7 @@
 		<div class="flex flex-wrap gap-2">
 			<Button variant="outline" size="sm" onclick={openAudiencePicker}>
 				<RefreshCwIcon class="size-3.5" aria-hidden="true" />
-				Change audience
+				Change {destinationLabel}
 			</Button>
 		</div>
 	{/if}

--- a/src/lib/components/waivers/PublicWaiverForm.svelte
+++ b/src/lib/components/waivers/PublicWaiverForm.svelte
@@ -27,7 +27,7 @@
 		title: string;
 		introCopy: string;
 		fields: WaiverField[];
-		marketingOptIn: { provider: 'mailchimp' | 'constant_contact'; label: string } | null;
+		marketingOptIn: { label: string } | null;
 	};
 
 	type BookingContext = {

--- a/src/lib/components/waivers/PublicWaiverForm.svelte
+++ b/src/lib/components/waivers/PublicWaiverForm.svelte
@@ -27,7 +27,7 @@
 		title: string;
 		introCopy: string;
 		fields: WaiverField[];
-		marketingOptIn: { provider: 'mailchimp'; label: string } | null;
+		marketingOptIn: { provider: 'mailchimp' | 'constant_contact'; label: string } | null;
 	};
 
 	type BookingContext = {

--- a/src/lib/components/waivers/SubmissionDetailSheet.svelte
+++ b/src/lib/components/waivers/SubmissionDetailSheet.svelte
@@ -284,6 +284,7 @@
 					answers={submission.answers}
 					marketingConsent={submission.marketingConsent}
 					marketingConsentLabel={submission.marketingConsentLabel}
+					marketingConsentDestinations={submission.marketingConsentDestinations}
 					signatureDataUrl={submission.signatureDataUrl}
 					submittedAt={submission.submittedAt}
 				/>

--- a/src/lib/components/waivers/WaiverReadonlyDocument.svelte
+++ b/src/lib/components/waivers/WaiverReadonlyDocument.svelte
@@ -25,6 +25,11 @@
 		answers?: Record<string, string | boolean | null>;
 		marketingConsent?: boolean;
 		marketingConsentLabel?: string | null;
+		marketingConsentDestinations?: Array<{
+			provider: 'mailchimp' | 'constant_contact';
+			audienceId: string;
+			audienceName: string;
+		}>;
 		signatureDataUrl?: string;
 		submittedAt?: number;
 	}
@@ -41,6 +46,7 @@
 		answers = {},
 		marketingConsent = false,
 		marketingConsentLabel = null,
+		marketingConsentDestinations = [],
 		signatureDataUrl = '',
 		submittedAt
 	}: Props = $props();
@@ -54,6 +60,13 @@
 	function formatDob(dob: string) {
 		const [y, m, d] = dob.split('-').map(Number);
 		return new Intl.DateTimeFormat('en-US', { dateStyle: 'long' }).format(new Date(y, m - 1, d));
+	}
+
+	function formatMarketingDestination(
+		destination: NonNullable<Props['marketingConsentDestinations']>[number]
+	) {
+		const provider = destination.provider === 'mailchimp' ? 'Mailchimp' : 'Constant Contact';
+		return `${provider}: ${destination.audienceName}`;
 	}
 </script>
 
@@ -135,6 +148,13 @@
 						<p class="mt-2 text-sm font-semibold">
 							{marketingConsent ? 'Opted in' : 'Did not opt in'}
 						</p>
+						{#if marketingConsentDestinations.length > 0}
+							<p class="mt-2 text-xs leading-relaxed text-muted-foreground">
+								Recorded destinations: {marketingConsentDestinations
+									.map(formatMarketingDestination)
+									.join(', ')}
+							</p>
+						{/if}
 					</div>
 				{/if}
 

--- a/src/routes/(app)/app/[workspaceSlug]/integrations/+page.svelte
+++ b/src/routes/(app)/app/[workspaceSlug]/integrations/+page.svelte
@@ -2,6 +2,8 @@
 	import type { FunctionReturnType } from 'convex/server';
 	import { useConvexClient } from 'convex-svelte';
 	import { dev } from '$app/environment';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { toast } from 'svelte-sonner';
 	import { api } from '$convex/_generated/api';
@@ -211,9 +213,9 @@
 			constantContactIntegrationQuery.isLoading ||
 			appContext.isLoading
 	);
-
 	let manualApiKey = $state('');
 	let selectedProviderKey = $state('bookeo');
+	let lastMarketingCallback = $state<string | null>(null);
 	let connectSheetOpen = $state(false);
 	let isStartingConnect = $state(false);
 	let isConnectingManually = $state(false);
@@ -221,6 +223,16 @@
 	let showManualFallback = $state(false);
 	let disconnectDialogOpen = $state(false);
 	let mailchimpDisconnectDialogOpen = $state(false);
+	const marketingCallbackProvider = $derived.by(() => {
+		const provider = page.url.searchParams.get('marketing');
+		return provider === 'mailchimp' || provider === 'constant-contact' ? provider : null;
+	});
+	const marketingCallbackStatus = $derived(page.url.searchParams.get('marketing-status'));
+	const shouldOpenMarketingAudiencePicker = $derived(
+		marketingCallbackProvider !== null &&
+			marketingCallbackStatus === 'authorized' &&
+			selectedProviderKey === marketingCallbackProvider
+	);
 	let disconnectConfirmation = $state('');
 	const disconnectConfirmationPhrase = 'DISCONNECT';
 	const canConfirmDisconnect = $derived(
@@ -329,6 +341,45 @@
 	function providerNameFor(providerKey: string) {
 		return ALL_PROVIDERS.find((provider) => provider.key === providerKey)?.name ?? providerKey;
 	}
+
+	async function clearMarketingCallbackParams() {
+		const params = new URLSearchParams(page.url.searchParams);
+		params.delete('marketing');
+		params.delete('marketing-status');
+		const pathname =
+			`/app/${page.params.workspaceSlug}/integrations` as `/app/${string}/integrations`;
+		const href = params.size > 0 ? `${pathname}?${params}` : pathname;
+		await goto(resolve(href as `/app/${string}/integrations`), {
+			replaceState: true,
+			noScroll: true,
+			keepFocus: true
+		});
+	}
+
+	function handleAudiencePickerOpened() {
+		void clearMarketingCallbackParams();
+	}
+
+	$effect(() => {
+		if (!marketingCallbackProvider || !marketingCallbackStatus) return;
+		selectedProviderKey = marketingCallbackProvider;
+		const callbackKey = `${marketingCallbackProvider}:${marketingCallbackStatus}`;
+		if (lastMarketingCallback === callbackKey) return;
+		lastMarketingCallback = callbackKey;
+		const providerName = providerNameFor(marketingCallbackProvider);
+		if (marketingCallbackStatus === 'authorized') {
+			toast.success(`${providerName} authorized. Choose a destination to finish setup.`);
+			return;
+		}
+		if (marketingCallbackStatus === 'denied') {
+			toast.error(`${providerName} authorization was cancelled.`);
+		} else if (marketingCallbackStatus === 'expired') {
+			toast.error(`${providerName} authorization expired. Please try again.`);
+		} else {
+			toast.error(`Unable to complete ${providerName} authorization. Please try again.`);
+		}
+		void clearMarketingCallbackParams();
+	});
 
 	function statusCopy(integration: Integration) {
 		const providerName = providerNameFor(integration.provider);
@@ -791,6 +842,8 @@
 						integration={selectedMarketingIntegration}
 						provider={selectedProvider.key === 'mailchimp' ? 'mailchimp' : 'constant_contact'}
 						canManage={selectedMarketingIntegration?.canManage ?? currentWorkspace.role === 'owner'}
+						requestAudiencePicker={shouldOpenMarketingAudiencePicker}
+						onAudiencePickerOpened={handleAudiencePickerOpened}
 						bind:disconnectDialogOpen={mailchimpDisconnectDialogOpen}
 					/>
 				{:else if selectedProviderIsConnected && selectedIntegration}

--- a/src/routes/(app)/app/[workspaceSlug]/integrations/+page.svelte
+++ b/src/routes/(app)/app/[workspaceSlug]/integrations/+page.svelte
@@ -130,8 +130,8 @@
 			key: 'constant-contact',
 			name: 'Constant Contact',
 			category: 'email',
-			availability: 'coming_soon',
-			status: 'Coming soon',
+			availability: 'available',
+			status: 'Available',
 			description: 'Sync signer contacts to Constant Contact lists.',
 			detailDescription:
 				'Constant Contact will let you route participant emails to a selected contact list after waiver signing.',
@@ -167,13 +167,27 @@
 	);
 
 	const integrations = $derived((integrationsQuery.data ?? []) as Integration[]);
-	const marketingIntegrationQuery = useProtectedQuery(
+	const mailchimpIntegrationQuery = useProtectedQuery(
 		api.marketingIntegrations.getWorkspaceMarketingIntegration,
-		() => (currentWorkspace ? { workspaceId: currentWorkspace.workspaceId } : 'skip'),
+		() =>
+			currentWorkspace
+				? { workspaceId: currentWorkspace.workspaceId, provider: 'mailchimp' as const }
+				: 'skip',
 		() => ({ keepPreviousData: true })
 	);
-	const marketingIntegration = $derived(
-		(marketingIntegrationQuery.data ?? null) as MarketingIntegration
+	const constantContactIntegrationQuery = useProtectedQuery(
+		api.marketingIntegrations.getWorkspaceMarketingIntegration,
+		() =>
+			currentWorkspace
+				? { workspaceId: currentWorkspace.workspaceId, provider: 'constant_contact' as const }
+				: 'skip',
+		() => ({ keepPreviousData: true })
+	);
+	const mailchimpIntegration = $derived(
+		(mailchimpIntegrationQuery.data ?? null) as MarketingIntegration
+	);
+	const constantContactIntegration = $derived(
+		(constantContactIntegrationQuery.data ?? null) as MarketingIntegration
 	);
 	const connectedIntegration = $derived(
 		integrations.find(
@@ -192,7 +206,10 @@
 			: currentWorkspace?.role === 'owner'
 	);
 	const isLoading = $derived(
-		integrationsQuery.isLoading || marketingIntegrationQuery.isLoading || appContext.isLoading
+		integrationsQuery.isLoading ||
+			mailchimpIntegrationQuery.isLoading ||
+			constantContactIntegrationQuery.isLoading ||
+			appContext.isLoading
 	);
 
 	let manualApiKey = $state('');
@@ -222,9 +239,15 @@
 	const selectedProviderIsConnected = $derived(
 		Boolean(selectedIntegration && selectedIntegration.status !== 'disconnected')
 	);
-	const selectedMailchimpIsConnected = $derived(
-		selectedProvider.key === 'mailchimp' &&
-			Boolean(marketingIntegration && marketingIntegration.status !== 'disconnected')
+	const selectedMarketingIntegration = $derived(
+		selectedProvider.key === 'mailchimp'
+			? mailchimpIntegration
+			: selectedProvider.key === 'constant-contact'
+				? constantContactIntegration
+				: null
+	);
+	const selectedMarketingIsConnected = $derived(
+		Boolean(selectedMarketingIntegration && selectedMarketingIntegration.status !== 'disconnected')
 	);
 	const webhookEventsQuery = useProtectedQuery(
 		api.integrations.listRecentWebhookEvents,
@@ -278,17 +301,23 @@
 	}
 
 	function hasActiveConnection(provider: ProviderDefinition) {
-		if (provider.key === 'mailchimp') {
-			return Boolean(marketingIntegration && marketingIntegration.status !== 'disconnected');
+		if (provider.key === 'mailchimp' || provider.key === 'constant-contact') {
+			return Boolean(
+				(provider.key === 'mailchimp' ? mailchimpIntegration : constantContactIntegration) &&
+				(provider.key === 'mailchimp' ? mailchimpIntegration : constantContactIntegration)
+					?.status !== 'disconnected'
+			);
 		}
 		const integration = integrationForProvider(provider.key);
 		return Boolean(integration && integration.status !== 'disconnected');
 	}
 
 	function providerStateFor(provider: ProviderDefinition): ProviderState {
-		if (provider.key === 'mailchimp') {
-			if (marketingIntegration && marketingIntegration.status !== 'disconnected') {
-				return marketingIntegration.status;
+		if (provider.key === 'mailchimp' || provider.key === 'constant-contact') {
+			const integration =
+				provider.key === 'mailchimp' ? mailchimpIntegration : constantContactIntegration;
+			if (integration && integration.status !== 'disconnected') {
+				return integration.status;
 			}
 			return provider.availability;
 		}
@@ -315,14 +344,15 @@
 		return `Connect ${providerName} to organize waiver submissions by booking.`;
 	}
 
-	function mailchimpStatusCopy(integration: NonNullable<MarketingIntegration>) {
+	function marketingStatusCopy(integration: NonNullable<MarketingIntegration>) {
+		const providerName = integration.provider === 'mailchimp' ? 'Mailchimp' : 'Constant Contact';
 		if (integration.status === 'pending_configuration') {
-			return 'Mailchimp is connected. Choose the audience that should receive opted-in signers.';
+			return `${providerName} is connected. Choose the list that should receive opted-in signers.`;
 		}
 		if (integration.status === 'error') {
-			return 'Mailchimp is connected, but recent contact syncs need attention.';
+			return `${providerName} is connected, but recent contact syncs need attention.`;
 		}
-		return 'Mailchimp is connected and sends opted-in signer contacts to the selected audience.';
+		return `${providerName} is connected and sends opted-in signer contacts to the selected list.`;
 	}
 
 	function formatTimestamp(timestamp: number | null) {
@@ -721,8 +751,8 @@
 							<p class="text-sm leading-relaxed text-muted-foreground">
 								{#if selectedProviderIsConnected && selectedIntegration}
 									{statusCopy(selectedIntegration)}
-								{:else if selectedMailchimpIsConnected && marketingIntegration}
-									{mailchimpStatusCopy(marketingIntegration)}
+								{:else if selectedMarketingIsConnected && selectedMarketingIntegration}
+									{marketingStatusCopy(selectedMarketingIntegration)}
 								{:else}
 									{selectedProvider.detailDescription}
 								{/if}
@@ -730,13 +760,13 @@
 						</div>
 					</div>
 
-					{#if selectedMailchimpIsConnected && marketingIntegration}
+					{#if selectedMarketingIsConnected && selectedMarketingIntegration}
 						<Button
 							size="sm"
 							variant="outline"
 							class="shrink-0 self-start"
 							onclick={() => (mailchimpDisconnectDialogOpen = true)}
-							disabled={convex.disabled || !marketingIntegration.canManage}
+							disabled={convex.disabled || !selectedMarketingIntegration.canManage}
 						>
 							<UnplugIcon class="size-3.5" aria-hidden="true" />
 							Disconnect
@@ -755,11 +785,12 @@
 					{/if}
 				</div>
 
-				{#if selectedProvider.key === 'mailchimp'}
+				{#if selectedProvider.key === 'mailchimp' || selectedProvider.key === 'constant-contact'}
 					<MailchimpIntegrationPanel
 						workspaceId={currentWorkspace.workspaceId}
-						integration={marketingIntegration}
-						canManage={marketingIntegration?.canManage ?? currentWorkspace.role === 'owner'}
+						integration={selectedMarketingIntegration}
+						provider={selectedProvider.key === 'mailchimp' ? 'mailchimp' : 'constant_contact'}
+						canManage={selectedMarketingIntegration?.canManage ?? currentWorkspace.role === 'owner'}
 						bind:disconnectDialogOpen={mailchimpDisconnectDialogOpen}
 					/>
 				{:else if selectedProviderIsConnected && selectedIntegration}


### PR DESCRIPTION
## Summary

- add Constant Contact V3 OAuth, list selection, and consent-gated signer contact upserts
- refresh and rotate Constant Contact access/refresh tokens only when the access token is expiring
- generalize the marketing integration boundary while preserving Mailchimp behavior
- let a workspace connect multiple email-marketing destinations and fan out each explicit opt-in to every selected destination
- retain a generic signer-facing consent prompt and immutable provider/list snapshots on the signed submission
- resume OAuth directly at the authorized provider’s audience/list picker, with clear success, cancellation, expiry, and error feedback

## Why

Implements WAI-65 so operators can collect generic marketing-and-promotions consent and send opted-in signers to every connected Mailchimp or Constant Contact list.

## Validation

- `pnpm run check`
- `pnpm run lint`
- `git diff --check`

## Deployment setup

Configure `CONSTANT_CONTACT_CLIENT_ID`, `CONSTANT_CONTACT_CLIENT_SECRET`, and `INTEGRATION_CREDENTIALS_ENCRYPTION_KEY` in the Convex runtime. Register `<CONVEX_SITE_URL>/constant-contact/callback` with the Constant Contact V3 app and request `contact_data offline_access`.

Production Constant Contact OAuth remains blocked on CTCT Technology Partner/public-access approval.

## Linear

https://linear.app/waiver-director/issue/WAI-65/implement-constant-contact-marketing-contact-list-flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Constant Contact integration with OAuth connection, list selection, contact synchronization, token refresh, and error handling.
  * Expanded marketing consent to support both Mailchimp and Constant Contact destinations.
  * Added provider-specific connection, audience selection, disconnection, and status handling.
  * Waiver submission details now display selected marketing destinations.

* **Documentation**
  * Added setup guidance and preview deployment documentation, including environment configuration and validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->