### PR TITLE
WAI-95 generate stable workspace URL handles

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,7 +9,7 @@ A business that collects waivers as part of running activities, services, events
 _Avoid_: Account, client, tenant
 
 **Workspace**:
-An isolated waiver-operations boundary that can represent a distinct business or a specific operational unit or location of a larger business.
+An isolated waiver-operations boundary. A user may own multiple workspaces for unrelated businesses or for locations of one business; every workspace remains independently scoped, and their relationship is not modeled.
 _Avoid_: Legal entity, global account
 
 **Waiver Operations**:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
+		"test": "node --test tests/**/*.test.ts",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"test": "node --test tests/**/*.test.ts",
+		"test": "node --test tests/*.test.ts",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/src/convex/lib/workspaceHandles.ts
+++ b/src/convex/lib/workspaceHandles.ts
@@ -1,0 +1,34 @@
+export const WORKSPACE_HANDLE_MAX_LENGTH = 48;
+
+const FALLBACK_WORKSPACE_HANDLE = 'workspace';
+const RESERVED_WORKSPACE_HANDLES = new Set(['workspaces']);
+
+export function workspaceHandleBase(name: string): string {
+	const handle = name
+		.normalize('NFKD')
+		.replace(/[\u0300-\u036f]/g, '')
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+		.slice(0, WORKSPACE_HANDLE_MAX_LENGTH)
+		.replace(/-+$/g, '');
+
+	return handle && !RESERVED_WORKSPACE_HANDLES.has(handle) ? handle : FALLBACK_WORKSPACE_HANDLE;
+}
+
+export function workspaceHandleCandidate(base: string, attempt: number): string {
+	if (!Number.isInteger(attempt) || attempt < 1) {
+		throw new Error('Workspace handle attempt must be a positive integer.');
+	}
+
+	if (attempt === 1) return base;
+
+	const suffix = `-${attempt}`;
+	const availableBaseLength = WORKSPACE_HANDLE_MAX_LENGTH - suffix.length;
+	if (availableBaseLength < 1) {
+		throw new Error('Workspace handle attempt exceeds the supported handle length.');
+	}
+
+	const candidateBase = base.slice(0, availableBaseLength).replace(/-+$/g, '');
+	return `${candidateBase || FALLBACK_WORKSPACE_HANDLE.slice(0, availableBaseLength)}${suffix}`;
+}

--- a/src/convex/workspaces.ts
+++ b/src/convex/workspaces.ts
@@ -16,9 +16,8 @@ import {
 	getWorkspaceMembership,
 	listWorkspaceMembershipsForUser
 } from './lib/workspaces';
+import { workspaceHandleBase, workspaceHandleCandidate } from './lib/workspaceHandles';
 
-const WORKSPACE_SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])$/;
-const RESERVED_SLUGS = ['workspaces'];
 const WORKSPACE_LOGO_ALLOWED_CONTENT_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp']);
 const WORKSPACE_LOGO_MAX_BYTES = 2 * 1024 * 1024;
 const WORKSPACE_LOGO_UPLOAD_TTL_MS = 30 * 60 * 1000;
@@ -60,8 +59,7 @@ const USER_DEFAULT_WORKSPACE_CLEANUP_BATCH = 50;
 
 export const createWorkspace = mutation({
 	args: {
-		name: v.string(),
-		slug: v.string()
+		name: v.string()
 	},
 	returns: v.object({
 		workspaceId: v.id('workspaces'),
@@ -77,7 +75,6 @@ export const createWorkspace = mutation({
 		}
 
 		const name = args.name.trim();
-		const slug = args.slug.trim().toLowerCase();
 
 		if (name.length < 2 || name.length > 80) {
 			throw new ConvexError({
@@ -85,31 +82,21 @@ export const createWorkspace = mutation({
 				message: 'Workspace name must be between 2 and 80 characters.'
 			});
 		}
-		if (!WORKSPACE_SLUG_REGEX.test(slug)) {
-			throw new ConvexError({
-				code: 'invalid_argument',
-				message:
-					'Workspace slug must be 2-48 characters: lowercase letters, numbers, and hyphens only. It must start and end with a letter or number.'
-			});
-		}
-		if (RESERVED_SLUGS.includes(slug)) {
-			throw new ConvexError({
-				code: 'invalid_argument',
-				message: `Workspace slug "${slug}" is reserved and cannot be used.`
-			});
-		}
-
 		await requireCanCreateWorkspace(ctx, user._id);
 
-		const existing = await ctx.db
-			.query('workspaces')
-			.withIndex('by_slug', (q) => q.eq('slug', slug))
-			.unique();
-		if (existing) {
-			throw new ConvexError({
-				code: 'already_exists',
-				message: 'Workspace slug already in use'
-			});
+		const handleBase = workspaceHandleBase(name);
+		let slug = handleBase;
+		// A concurrent insert changes this indexed read and causes Convex to retry the mutation.
+		for (let attempt = 1; ; attempt += 1) {
+			const candidate = workspaceHandleCandidate(handleBase, attempt);
+			const existing = await ctx.db
+				.query('workspaces')
+				.withIndex('by_slug', (q) => q.eq('slug', candidate))
+				.unique();
+			if (!existing) {
+				slug = candidate;
+				break;
+			}
 		}
 
 		const workspaceId = await ctx.db.insert('workspaces', {
@@ -203,14 +190,12 @@ export const listCurrentUserWorkspaces = query({
 export const updateWorkspace = mutation({
 	args: {
 		workspaceId: v.id('workspaces'),
-		name: v.optional(v.string()),
-		slug: v.optional(v.string())
+		name: v.optional(v.string())
 	},
 	returns: v.object({
 		workspaceId: v.id('workspaces'),
 		name: v.string(),
-		slug: v.string(),
-		slugChanged: v.boolean()
+		slug: v.string()
 	}),
 	handler: async (ctx, args) => {
 		await requireWorkspaceOwner(ctx, args.workspaceId, 'change workspace settings');
@@ -220,8 +205,7 @@ export const updateWorkspace = mutation({
 			throw new ConvexError({ code: 'not_found', message: 'Workspace not found.' });
 		}
 
-		const patch: { name?: string; slug?: string } = {};
-		let slugChanged = false;
+		const patch: { name?: string } = {};
 
 		if (args.name !== undefined) {
 			const name = args.name.trim();
@@ -232,37 +216,6 @@ export const updateWorkspace = mutation({
 				});
 			}
 			if (name !== workspace.name) patch.name = name;
-		}
-
-		if (args.slug !== undefined) {
-			const slug = args.slug.trim().toLowerCase();
-			if (!WORKSPACE_SLUG_REGEX.test(slug)) {
-				throw new ConvexError({
-					code: 'invalid_argument',
-					message:
-						'Workspace slug must be 2-48 characters: lowercase letters, numbers, and hyphens only. It must start and end with a letter or number.'
-				});
-			}
-			if (RESERVED_SLUGS.includes(slug)) {
-				throw new ConvexError({
-					code: 'invalid_argument',
-					message: `Workspace slug "${slug}" is reserved and cannot be used.`
-				});
-			}
-			if (slug !== workspace.slug) {
-				const existing = await ctx.db
-					.query('workspaces')
-					.withIndex('by_slug', (q) => q.eq('slug', slug))
-					.unique();
-				if (existing && existing._id !== args.workspaceId) {
-					throw new ConvexError({
-						code: 'already_exists',
-						message: 'Workspace slug already in use'
-					});
-				}
-				patch.slug = slug;
-				slugChanged = true;
-			}
 		}
 
 		if (Object.keys(patch).length > 0) {
@@ -277,8 +230,7 @@ export const updateWorkspace = mutation({
 		return {
 			workspaceId: next._id,
 			name: next.name,
-			slug: next.slug,
-			slugChanged
+			slug: next.slug
 		};
 	}
 });
@@ -464,7 +416,7 @@ export const archiveWorkspace = mutation({
 		if (args.confirmSlug.trim() !== workspace.slug) {
 			throw new ConvexError({
 				code: 'invalid_argument',
-				message: 'Confirmation text does not match the workspace slug.'
+				message: 'Confirmation text does not match the workspace URL handle.'
 			});
 		}
 

--- a/src/convex/workspaces.ts
+++ b/src/convex/workspaces.ts
@@ -56,6 +56,7 @@ const WORKSPACE_PRIMARY_CLEANUP_TABLE_NAMES = WORKSPACE_CLEANUP_TABLE_NAMES.filt
 );
 const CLEANUP_BATCH_PER_TABLE = 50;
 const USER_DEFAULT_WORKSPACE_CLEANUP_BATCH = 50;
+const MAX_WORKSPACE_HANDLE_ATTEMPTS = 1000;
 
 export const createWorkspace = mutation({
 	args: {
@@ -85,9 +86,9 @@ export const createWorkspace = mutation({
 		await requireCanCreateWorkspace(ctx, user._id);
 
 		const handleBase = workspaceHandleBase(name);
-		let slug = handleBase;
+		let slug: string | null = null;
 		// A concurrent insert changes this indexed read and causes Convex to retry the mutation.
-		for (let attempt = 1; ; attempt += 1) {
+		for (let attempt = 1; attempt <= MAX_WORKSPACE_HANDLE_ATTEMPTS; attempt += 1) {
 			const candidate = workspaceHandleCandidate(handleBase, attempt);
 			const existing = await ctx.db
 				.query('workspaces')
@@ -97,6 +98,12 @@ export const createWorkspace = mutation({
 				slug = candidate;
 				break;
 			}
+		}
+		if (!slug) {
+			throw new ConvexError({
+				code: 'internal_error',
+				message: 'Unable to generate a unique workspace URL handle. Please try again.'
+			});
 		}
 
 		const workspaceId = await ctx.db.insert('workspaces', {

--- a/src/lib/components/app/WorkspaceSearchDialog.svelte
+++ b/src/lib/components/app/WorkspaceSearchDialog.svelte
@@ -204,9 +204,17 @@
 		{
 			key: 'settings-general',
 			label: 'General settings',
-			description: 'Workspace name and URL slug',
+			description: 'Workspace name and URL handle',
 			path: 'settings/general',
-			aliases: ['general', 'workspace name', 'workspace slug', 'slug', 'url slug', 'identity'],
+			aliases: [
+				'general',
+				'workspace name',
+				'workspace handle',
+				'handle',
+				'slug',
+				'url handle',
+				'identity'
+			],
 			icon: Building2Icon,
 			showWhenEmpty: false
 		},

--- a/src/lib/components/workspaces/CreateWorkspaceForm.svelte
+++ b/src/lib/components/workspaces/CreateWorkspaceForm.svelte
@@ -20,40 +20,17 @@
 	}
 
 	const convex = useConvexClient();
-	const workspaceSlugRegex = /^[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])$/;
-
 	let { onCreated, submitLabel = 'Create workspace', autoFocusName = false }: Props = $props();
 
 	let name = $state('');
-	let slug = $state('');
-	let slugEdited = $state(false);
 	let isSubmitting = $state(false);
 	let hasAttemptedSubmit = $state(false);
 	let submitError = $state<string | null>(null);
 	let isSuccess = $state(false);
 
-	function sanitizeSlug(value: string): string {
-		return value
-			.toLowerCase()
-			.trim()
-			.replace(/[\s_]+/g, '-')
-			.replace(/[^a-z0-9-]/g, '')
-			.replace(/-+/g, '-')
-			.replace(/^-|-$/g, '')
-			.slice(0, 48)
-			.replace(/-$/g, '');
-	}
-
 	const trimmedName = $derived(name.trim());
 	const nameValid = $derived(trimmedName.length >= 2 && trimmedName.length <= 80);
-	const slugValid = $derived(workspaceSlugRegex.test(slug));
-	const canSubmit = $derived(nameValid && slugValid && !isSubmitting && !isSuccess);
-
-	$effect(() => {
-		if (!slugEdited) {
-			slug = sanitizeSlug(name);
-		}
-	});
+	const canSubmit = $derived(nameValid && !isSubmitting && !isSuccess);
 
 	const initials = $derived(
 		trimmedName
@@ -68,29 +45,6 @@
 		return hasAttemptedSubmit && !nameValid
 			? 'Use 2-80 characters for the workspace name.'
 			: 'The display name for your business.';
-	}
-
-	function getSlugHint(): string {
-		if (hasAttemptedSubmit && !slugValid) {
-			return 'Use 2-48 lowercase letters or numbers. Hyphens are allowed only in the middle.';
-		}
-
-		if (!slug) {
-			return 'Lowercase letters, numbers, and hyphens only.';
-		}
-
-		return slugEdited
-			? 'This becomes part of your workspace URL.'
-			: 'Generated from your workspace name.';
-	}
-
-	function handleSlugInput(event: Event) {
-		submitError = null;
-		const raw = (event.target as HTMLInputElement).value;
-		const nextSlug = sanitizeSlug(raw);
-
-		slugEdited = nextSlug.length > 0;
-		slug = nextSlug;
 	}
 
 	function getSubmitErrorMessage(error: unknown): string {
@@ -126,8 +80,7 @@
 			}
 
 			const result = await convex.mutation(api.workspaces.createWorkspace, {
-				name: trimmedName,
-				slug
+				name: trimmedName
 			});
 
 			if (onCreated) {
@@ -168,7 +121,7 @@
 			</p>
 			<p class="truncate font-mono text-xs text-muted-foreground">
 				<span class="opacity-60">app /</span>
-				<span class="text-primary/85">{slug || 'workspace-slug'}</span>
+				<span class="text-primary/85">generated after creation</span>
 			</p>
 		</div>
 
@@ -211,45 +164,10 @@
 			</p>
 		</div>
 
-		<div class="space-y-2">
-			<label class="text-sm font-medium text-foreground" for="workspace-slug">Workspace slug</label>
-			<div class="relative">
-				<span
-					class="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 font-mono text-[0.8125rem] text-muted-foreground"
-					aria-hidden="true"
-				>
-					app /
-				</span>
-				<Input
-					id="workspace-slug"
-					name="slug"
-					type="text"
-					autocomplete="off"
-					placeholder="atlas-escape"
-					class="h-11 rounded-lg border-border/70 bg-background/70 px-3 pl-17 font-mono text-sm shadow-none placeholder:text-muted-foreground/70 focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/20 md:text-sm"
-					value={slug}
-					required
-					minlength={2}
-					maxlength={48}
-					disabled={isSubmitting || isSuccess}
-					aria-invalid={hasAttemptedSubmit && !slugValid}
-					aria-describedby="workspace-slug-hint"
-					spellcheck={false}
-					autocapitalize="off"
-					autocorrect="off"
-					inputmode="text"
-					pattern={workspaceSlugRegex.source}
-					oninput={handleSlugInput}
-				/>
-			</div>
-			<p
-				id="workspace-slug-hint"
-				class:text-destructive={hasAttemptedSubmit && !slugValid}
-				class="text-xs leading-5 text-muted-foreground"
-			>
-				{getSlugHint()}
-			</p>
-		</div>
+		<p class="text-xs leading-5 text-muted-foreground">
+			A unique, permanent URL handle is generated from this name after creation. You can rename the
+			workspace later without changing its URL.
+		</p>
 	</div>
 
 	{#if submitError}

--- a/src/routes/(app)/app/[workspaceSlug]/settings/danger/+page.svelte
+++ b/src/routes/(app)/app/[workspaceSlug]/settings/danger/+page.svelte
@@ -82,7 +82,7 @@
 			<div class="rounded-md border border-destructive/25 bg-destructive/5 px-3.5 py-3">
 				<p class="text-xs leading-5 text-destructive/85">
 					Deleting <strong>{currentWorkspace?.name}</strong> will hide it from your team and break
-					any public waiver links sharing
+					its app URL and public waiver links. Its app URL is
 					<code class="rounded bg-destructive/10 px-1 py-0.5 font-mono text-[11px]"
 						>app/{currentWorkspace?.slug}</code
 					>. Customer records, submissions, and bookings will no longer be accessible from the app.
@@ -156,7 +156,7 @@
 			{#if !isOwner}
 				<span class="status-idle">Only owners can delete a workspace</span>
 			{:else}
-				<span class="status-idle">No undo. Type the slug to confirm.</span>
+				<span class="status-idle">No undo. Type the URL handle to confirm.</span>
 			{/if}
 		</div>
 		<Button

--- a/src/routes/(app)/app/[workspaceSlug]/settings/general/+page.svelte
+++ b/src/routes/(app)/app/[workspaceSlug]/settings/general/+page.svelte
@@ -109,12 +109,24 @@
 	title="Workspace URL handle"
 	description="The stable path used in your app URLs. It is generated when the workspace is created and cannot be changed."
 >
-	<div class="handle-field">
+	<div
+		class="handle-field"
+		class:handle-field--disabled={!currentWorkspace}
+		aria-disabled={!currentWorkspace}
+	>
 		<span class="handle-prefix" aria-hidden="true">app /</span>
-		<code class="handle-value">{currentWorkspace?.slug ?? 'workspace-handle'}</code>
+		{#if currentWorkspace}
+			<code class="handle-value">{currentWorkspace.slug}</code>
+		{:else}
+			<span class="handle-placeholder">Workspace handle loading…</span>
+		{/if}
 	</div>
 	<p class="settings-hint">
-		Renaming the workspace does not change this handle or any existing links.
+		{#if currentWorkspace}
+			Renaming the workspace does not change this handle or any existing links.
+		{:else}
+			The workspace URL handle will appear after the workspace loads.
+		{/if}
 	</p>
 
 	{#snippet footer()}
@@ -170,6 +182,10 @@
 		background: color-mix(in srgb, var(--muted) 28%, transparent);
 	}
 
+	.handle-field--disabled {
+		opacity: 0.55;
+	}
+
 	.handle-prefix,
 	.handle-value {
 		font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, monospace;
@@ -183,5 +199,10 @@
 	.handle-value {
 		color: var(--foreground);
 		font-weight: 500;
+	}
+
+	.handle-placeholder {
+		color: var(--muted-foreground);
+		font-size: 0.78rem;
 	}
 </style>

--- a/src/routes/(app)/app/[workspaceSlug]/settings/general/+page.svelte
+++ b/src/routes/(app)/app/[workspaceSlug]/settings/general/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { useConvexClient } from 'convex-svelte';
 	import { toast } from 'svelte-sonner';
@@ -10,21 +8,9 @@
 
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
-	import {
-		Dialog,
-		DialogContent,
-		DialogDescription,
-		DialogFooter,
-		DialogHeader,
-		DialogTitle
-	} from '$lib/components/ui/dialog';
 	import SettingsSection from '$lib/components/settings/SettingsSection.svelte';
-	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import LoaderIcon from '@lucide/svelte/icons/loader';
 	import CheckIcon from '@lucide/svelte/icons/check';
-
-	const WORKSPACE_SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])$/;
-	const RESERVED_SLUGS = ['workspaces'];
 
 	const convex = useConvexClient();
 	const appContext = useAppContext();
@@ -33,51 +19,22 @@
 	);
 
 	let name = $state('');
-	let slug = $state('');
 	let loadedWorkspaceId = $state<string | null>(null);
 	let isSavingName = $state(false);
 	let nameSavedAt = $state<number | null>(null);
-
-	let confirmOpen = $state(false);
-	let confirmTyped = $state('');
-	let isSavingSlug = $state(false);
 
 	$effect(() => {
 		if (!currentWorkspace) return;
 		if (loadedWorkspaceId !== currentWorkspace.workspaceId) {
 			name = currentWorkspace.name;
-			slug = currentWorkspace.slug;
 			loadedWorkspaceId = currentWorkspace.workspaceId;
 			nameSavedAt = null;
 		}
 	});
 
-	function sanitizeSlug(value: string): string {
-		return value
-			.toLowerCase()
-			.trim()
-			.replace(/[\s_]+/g, '-')
-			.replace(/[^a-z0-9-]/g, '')
-			.replace(/-+/g, '-')
-			.replace(/^-|-$/g, '')
-			.slice(0, 48)
-			.replace(/-$/g, '');
-	}
-
 	const trimmedName = $derived(name.trim());
 	const nameChanged = $derived(Boolean(currentWorkspace && trimmedName !== currentWorkspace.name));
 	const nameValid = $derived(trimmedName.length >= 2 && trimmedName.length <= 80);
-
-	const slugChanged = $derived(Boolean(currentWorkspace && slug !== currentWorkspace.slug));
-	const slugValid = $derived(
-		Boolean(slug) && WORKSPACE_SLUG_REGEX.test(slug) && !RESERVED_SLUGS.includes(slug)
-	);
-	const slugMatchesConfirm = $derived(confirmTyped.trim() === slug);
-
-	function handleSlugInput(event: Event) {
-		const raw = (event.target as HTMLInputElement).value;
-		slug = sanitizeSlug(raw);
-	}
 
 	async function saveName() {
 		if (!currentWorkspace || !nameChanged || !nameValid) return;
@@ -95,122 +52,7 @@
 			isSavingName = false;
 		}
 	}
-
-	function openConfirm() {
-		confirmTyped = '';
-		confirmOpen = true;
-	}
-
-	async function confirmSlugChange() {
-		if (!currentWorkspace || !slugChanged || !slugValid || !slugMatchesConfirm) return;
-		isSavingSlug = true;
-		try {
-			const result = await convex.mutation(api.workspaces.updateWorkspace, {
-				workspaceId: currentWorkspace.workspaceId,
-				slug
-			});
-			confirmOpen = false;
-			toast.success('Workspace slug updated. Redirecting…');
-			await goto(resolve(`/app/${result.slug}/settings/general` as const), {
-				replaceState: true
-			});
-		} catch (err) {
-			toast.error(getConvexErrorMessage(err, 'Failed to update workspace slug.'));
-		} finally {
-			isSavingSlug = false;
-		}
-	}
-
-	function resetSlug() {
-		if (!currentWorkspace) return;
-		slug = currentWorkspace.slug;
-	}
 </script>
-
-<!-- Slug change confirmation -->
-<Dialog bind:open={confirmOpen}>
-	<DialogContent class="overflow-hidden p-0 sm:max-w-md">
-		<DialogHeader class="space-y-2 border-b border-border px-6 py-5">
-			<div class="flex items-start gap-3">
-				<div
-					class="flex size-8 items-center justify-center rounded-md border text-muted-foreground"
-				>
-					<TriangleAlertIcon class="size-5" />
-				</div>
-				<div class="min-w-0 flex-1">
-					<DialogTitle class="text-base">Change workspace slug?</DialogTitle>
-					<DialogDescription class="text-xs">This breaks existing shared links.</DialogDescription>
-				</div>
-			</div>
-		</DialogHeader>
-
-		<div class="space-y-4 px-6 py-5">
-			<div class="rounded-md border px-3.5 py-3">
-				<p class="text-xs leading-5 text-muted-foreground">
-					Existing public waiver links containing
-					<code class="rounded bg-muted px-1 py-0.5 font-mono text-[11px] text-foreground"
-						>{currentWorkspace?.slug}</code
-					>
-					will break. Anyone sharing the old URL will get a 404. Update your QR codes, embeds, and any
-					links you've handed out.
-				</p>
-			</div>
-
-			<div class="space-y-2 rounded-md bg-muted/40 px-3.5 py-3">
-				<p class="text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
-					You're changing
-				</p>
-				<div class="flex items-center gap-2 font-mono text-xs">
-					<span class="text-muted-foreground line-through">app/{currentWorkspace?.slug}</span>
-					<span class="text-muted-foreground">→</span>
-					<span class="font-medium text-foreground">app/{slug}</span>
-				</div>
-			</div>
-
-			<div class="space-y-2">
-				<label class="text-xs font-medium text-foreground" for="confirm-slug">
-					Type
-					<code class="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">{slug}</code>
-					to confirm
-				</label>
-				<Input
-					id="confirm-slug"
-					bind:value={confirmTyped}
-					placeholder={slug}
-					class="font-mono text-sm"
-					autocomplete="off"
-					autocorrect="off"
-					spellcheck={false}
-				/>
-			</div>
-		</div>
-
-		<DialogFooter class="border-t border-border bg-muted/20 px-6 py-3">
-			<Button
-				variant="outline"
-				size="sm"
-				onclick={() => (confirmOpen = false)}
-				disabled={isSavingSlug}
-			>
-				Cancel
-			</Button>
-			<Button
-				variant="destructive"
-				size="sm"
-				disabled={!slugMatchesConfirm || isSavingSlug}
-				onclick={confirmSlugChange}
-				class="gap-1.5"
-			>
-				{#if isSavingSlug}
-					<LoaderIcon class="size-3.5 animate-spin" />
-					Updating
-				{:else}
-					Change slug permanently
-				{/if}
-			</Button>
-		</DialogFooter>
-	</DialogContent>
-</Dialog>
 
 <SettingsSection
 	title="Workspace name"
@@ -264,72 +106,20 @@
 </SettingsSection>
 
 <SettingsSection
-	title="Workspace URL slug"
-	description="The path used in app URLs and public waiver links. Changing this breaks any URL you've already shared."
+	title="Workspace URL handle"
+	description="The stable path used in your app URLs. It is generated when the workspace is created and cannot be changed."
 >
-	<div class="space-y-2">
-		<div class="slug-field">
-			<span class="slug-prefix" aria-hidden="true">app /</span>
-			<Input
-				id="workspace-slug"
-				value={slug}
-				oninput={handleSlugInput}
-				placeholder="atlas-escape"
-				maxlength={48}
-				disabled={!currentWorkspace}
-				spellcheck={false}
-				autocomplete="off"
-				autocapitalize="off"
-				autocorrect="off"
-				class="slug-input h-10 font-mono"
-			/>
-		</div>
-		<p class="settings-hint" class:invalid={slugChanged && !slugValid}>
-			{#if slugChanged && !slugValid}
-				2–48 lowercase letters, numbers, and hyphens. Must start/end with a letter or number and
-				cannot be reserved.
-			{:else if slugChanged}
-				Will change your URL from
-				<code class="settings-mono">app/{currentWorkspace?.slug}</code>
-				to <code class="settings-mono">app/{slug}</code>.
-			{:else}
-				Lowercase letters, numbers, and hyphens. Hyphens only in the middle.
-			{/if}
-		</p>
+	<div class="handle-field">
+		<span class="handle-prefix" aria-hidden="true">app /</span>
+		<code class="handle-value">{currentWorkspace?.slug ?? 'workspace-handle'}</code>
 	</div>
-
-	<aside class="slug-warning">
-		<TriangleAlertIcon class="size-4 shrink-0" />
-		<div class="space-y-1">
-			<p class="slug-warning-title">Slug changes are disruptive</p>
-			<p class="slug-warning-desc">
-				Public waiver links you've shared, QR codes, and any external bookmark using
-				<code class="settings-mono">app/{currentWorkspace?.slug}</code>
-				will stop working. We don't redirect old slugs.
-			</p>
-		</div>
-	</aside>
+	<p class="settings-hint">
+		Renaming the workspace does not change this handle or any existing links.
+	</p>
 
 	{#snippet footer()}
 		<div class="settings-section-foot-status">
-			{#if slugChanged}
-				<span class="status-dirty">Pending confirmation</span>
-			{:else}
-				<span class="status-idle">Up to date</span>
-			{/if}
-		</div>
-		<div class="flex items-center gap-2">
-			{#if slugChanged}
-				<Button variant="ghost" size="sm" onclick={resetSlug} disabled={isSavingSlug}>Reset</Button>
-			{/if}
-			<Button
-				size="sm"
-				variant="destructive"
-				disabled={!slugChanged || !slugValid || isSavingSlug}
-				onclick={openConfirm}
-			>
-				Change slug…
-			</Button>
+			<span class="status-idle">Stable URL handle</span>
 		</div>
 	{/snippet}
 </SettingsSection>
@@ -368,59 +158,30 @@
 		color: var(--destructive);
 	}
 
-	.settings-mono {
-		font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, monospace;
-		font-size: 0.7rem;
-		padding: 0.05rem 0.35rem;
-		background: color-mix(in srgb, var(--muted) 60%, transparent);
-		border-radius: var(--radius-xs);
-		color: var(--foreground);
-	}
-
-	.slug-field {
+	.handle-field {
 		position: relative;
 		display: flex;
 		align-items: center;
+		gap: 0.25rem;
+		min-height: 2.5rem;
+		padding: 0 0.75rem;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		background: color-mix(in srgb, var(--muted) 28%, transparent);
 	}
 
-	.slug-prefix {
-		position: absolute;
-		left: 0.75rem;
-		top: 50%;
-		transform: translateY(-50%);
+	.handle-prefix,
+	.handle-value {
 		font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, monospace;
 		font-size: 0.78rem;
+	}
+
+	.handle-prefix {
 		color: var(--muted-foreground);
-		opacity: 0.7;
-		pointer-events: none;
-		z-index: 1;
 	}
 
-	.slug-field :global(.slug-input) {
-		padding-left: 3.5rem;
-		width: 100%;
-	}
-
-	.slug-warning {
-		display: flex;
-		gap: 0.65rem;
-		align-items: flex-start;
-		padding: 0.85rem 1rem;
-		border-radius: var(--radius-md);
-		background: color-mix(in srgb, var(--destructive) 6%, transparent);
-		border: 1px solid color-mix(in srgb, var(--destructive) 20%, var(--border));
-		color: color-mix(in srgb, var(--destructive) 70%, var(--foreground));
-	}
-
-	.slug-warning-title {
-		font-size: 0.78rem;
-		font-weight: 600;
-		color: color-mix(in srgb, var(--destructive) 70%, var(--foreground));
-	}
-
-	.slug-warning-desc {
-		font-size: 0.72rem;
-		line-height: 1.5;
-		color: color-mix(in srgb, var(--destructive) 48%, var(--muted-foreground));
+	.handle-value {
+		color: var(--foreground);
+		font-weight: 500;
 	}
 </style>

--- a/tests/workspaceHandles.test.ts
+++ b/tests/workspaceHandles.test.ts
@@ -10,6 +10,7 @@ test('creates a URL-safe workspace handle from a display name', () => {
 	assert.equal(workspaceHandleBase('  Caf\u00e9 & Co.  '), 'cafe-co');
 	assert.equal(workspaceHandleBase('Workspaces'), 'workspace');
 	assert.equal(workspaceHandleBase('!!!'), 'workspace');
+	assert.equal(workspaceHandleBase(''), 'workspace');
 });
 
 test('creates deterministic collision-safe handle candidates', () => {
@@ -18,6 +19,8 @@ test('creates deterministic collision-safe handle candidates', () => {
 	assert.equal(workspaceHandleCandidate(base, 1), 'atlas-escape-vr');
 	assert.equal(workspaceHandleCandidate(base, 2), 'atlas-escape-vr-2');
 	assert.equal(workspaceHandleCandidate(base, 3), 'atlas-escape-vr-3');
+	assert.throws(() => workspaceHandleCandidate(base, 0), /positive integer/);
+	assert.throws(() => workspaceHandleCandidate(base, -1), /positive integer/);
 });
 
 test('preserves the maximum handle length when adding a collision suffix', () => {

--- a/tests/workspaceHandles.test.ts
+++ b/tests/workspaceHandles.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	WORKSPACE_HANDLE_MAX_LENGTH,
+	workspaceHandleBase,
+	workspaceHandleCandidate
+} from '../src/convex/lib/workspaceHandles.ts';
+
+test('creates a URL-safe workspace handle from a display name', () => {
+	assert.equal(workspaceHandleBase('  Caf\u00e9 & Co.  '), 'cafe-co');
+	assert.equal(workspaceHandleBase('Workspaces'), 'workspace');
+	assert.equal(workspaceHandleBase('!!!'), 'workspace');
+});
+
+test('creates deterministic collision-safe handle candidates', () => {
+	const base = workspaceHandleBase('Atlas Escape & VR');
+
+	assert.equal(workspaceHandleCandidate(base, 1), 'atlas-escape-vr');
+	assert.equal(workspaceHandleCandidate(base, 2), 'atlas-escape-vr-2');
+	assert.equal(workspaceHandleCandidate(base, 3), 'atlas-escape-vr-3');
+});
+
+test('preserves the maximum handle length when adding a collision suffix', () => {
+	const base = workspaceHandleBase('a'.repeat(80));
+	const candidate = workspaceHandleCandidate(base, 12);
+
+	assert.equal(candidate.length, WORKSPACE_HANDLE_MAX_LENGTH);
+	assert.equal(candidate, `${'a'.repeat(45)}-12`);
+});


### PR DESCRIPTION
## Summary

- generate globally unique, URL-safe workspace handles from the display name during workspace creation
- retain the existing `slug` storage field and routes so existing app links remain valid
- make the generated handle stable across workspace renames and remove client-side handle editing
- clarify the distinct display-name and URL-handle concepts across creation, settings, search, and deletion flows

## Why

Workspace display names are now repeatable, so people can create independently scoped workspaces with the same business name without inventing a globally unique URL identifier.

## User impact

New workspaces receive a permanent flat `/app/{workspaceHandle}` URL automatically. Renaming a workspace does not change its app URL or public waiver URL.

## Validation

- `pnpm test`
- `pnpm run check`
- `pnpm run lint`

Closes #53

Linear: https://linear.app/waiver-director/issue/WAI-95/generate-unique-workspace-url-handles-while-allowing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace URL handles are now generated automatically from workspace names.
  * Handles are normalized, unique, length-limited, and remain stable after creation.
  * Workspace creation and editing flows now focus on the workspace name, with the generated handle displayed as read-only.

* **Bug Fixes**
  * Improved handling of handle collisions and reserved names.

* **Documentation**
  * Updated terminology and guidance from “slug” to “URL handle” across workspace settings and confirmation dialogs.

* **Tests**
  * Added coverage for handle normalization, collision suffixes, and length limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->