### PR TITLE
chore: regenerate Convex API types

### DIFF
--- a/src/convex/_generated/api.d.ts
+++ b/src/convex/_generated/api.d.ts
@@ -25,6 +25,7 @@ import type * as lib_customers from "../lib/customers.js";
 import type * as lib_marketing from "../lib/marketing.js";
 import type * as lib_submissions from "../lib/submissions.js";
 import type * as lib_waivers from "../lib/waivers.js";
+import type * as lib_workspaceHandles from "../lib/workspaceHandles.js";
 import type * as lib_workspaces from "../lib/workspaces.js";
 import type * as mailchimp from "../mailchimp.js";
 import type * as marketingIntegrations from "../marketingIntegrations.js";
@@ -57,6 +58,7 @@ declare const fullApi: ApiFromModules<{
   "lib/marketing": typeof lib_marketing;
   "lib/submissions": typeof lib_submissions;
   "lib/waivers": typeof lib_waivers;
+  "lib/workspaceHandles": typeof lib_workspaceHandles;
   "lib/workspaces": typeof lib_workspaces;
   mailchimp: typeof mailchimp;
   marketingIntegrations: typeof marketingIntegrations;


### PR DESCRIPTION
## Summary

Regenerates the Convex API type manifest after adding the `workspaceHandles` backend helper.

## Why

The merged WAI-95 source change introduced `src/convex/lib/workspaceHandles.ts`, but its generated module registration was absent from `src/convex/_generated/api.d.ts`.

## Validation

- `git diff --check`
- `pnpm exec prettier --check src/convex/_generated/api.d.ts`

Convex codegen was also attempted in an isolated worktree; it requires a configured deployment and made no additional changes.