### PR TITLE
docs: define canceled and manual follow-up scheduling

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -152,8 +152,12 @@ _Avoid_: Draft campaign, missing email
 The send timing for a follow-up candidate, initially calculated from the booking snapshot captured on the signed submission rather than silently recalculated from later provider changes.
 _Avoid_: Live booking reschedule, implicit timing change
 
+**Manual Follow-Up Schedule**:
+An Owner- or Staff-selected future date and time, expressed in the operator's local time and saved as one exact send instant, for one Unscheduled Follow-Up or an explicitly selected group of Unscheduled Follow-Ups. It is distinct from the booking-derived Follow-Up Schedule; Canceled Follow-Ups are excluded from batch scheduling, a batch applies only if every selected Follow-Up remains eligible, an operator changes a schedule by unscheduling it before choosing a new time, and provider-booking cancellation suppresses the pending delivery.
+_Avoid_: Automatic follow-up timing, canceled-follow-up restore
+
 **Canceled Follow-Up**:
-A follow-up candidate removed from automatic sending because its booking was canceled before delivery; it remains visible in follow-up history but is not part of the send queue.
+A follow-up candidate whose scheduled delivery was pending is permanently removed from sending because its booking was canceled before delivery; it remains visible in follow-up history with its cancellation reason and time, and later booking reactivation requires an operator to send it explicitly. Follow-ups without a schedule, and follow-ups already sent or failed, retain their existing status; Owners and Staff may make an explicit one-off send, but a canceled follow-up never returns to automatic or bulk delivery.
 _Avoid_: Automatic thank-you, deleted follow-up, queued follow-up
 
 **Unscheduled Follow-Up**:


### PR DESCRIPTION
## Summary

- define **Manual Follow-Up Schedule** in `CONTEXT.md`
- clarify the terminal **Canceled Follow-Up** state and its operational constraints

## Why

These terms are the shared domain language for the related follow-up work; they distinguish manual scheduling from booking-derived timing and prevent canceled follow-ups from re-entering automated delivery.

Related Linear issues: [WAI-90](https://linear.app/waiver-director/issue/WAI-90/cancel-queued-follow-ups-when-provider-booking-is-canceled) and [WAI-97](https://linear.app/waiver-director/issue/WAI-97/manual-follow-up-scheduling).

## Validation

- `pnpm run check`
- `pnpm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a glossary definition for manual follow-up schedules, including timing and eligibility details.
  * Clarified canceled follow-up behavior, including history visibility, status handling, reactivation, and exclusion from automatic or bulk delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->