### PR TITLE
Fix waiver theming and rich-text output

### DIFF
--- a/src/convex/emails.ts
+++ b/src/convex/emails.ts
@@ -15,6 +15,7 @@ import { internal } from './_generated/api';
 import { requireWorkspaceFeature } from './lib/billing';
 import { requireWorkspaceMember } from './lib/waivers';
 import { escapeHtml, sanitizeRichTextHtml } from '../lib/utils/rich-text';
+import { richTextHtmlToPlainText } from '../lib/utils/rich-text-shared';
 
 const DEFAULT_SEND_AFTER_AMOUNT = 2;
 const DEFAULT_SEND_AFTER_UNIT = 'hours' as const;
@@ -1112,47 +1113,11 @@ function resolveHtmlVariables(
 	});
 }
 
-function decodeHtmlEntities(value: string): string {
-	return value.replace(
-		/&(#(\d+)|#x([\da-f]+)|amp|lt|gt|quot|apos);/gi,
-		(entity, _match, dec, hex) => {
-			if (dec) return String.fromCodePoint(Number(dec));
-			if (hex) return String.fromCodePoint(Number.parseInt(hex, 16));
-
-			switch (entity.toLowerCase()) {
-				case '&amp;':
-					return '&';
-				case '&lt;':
-					return '<';
-				case '&gt;':
-					return '>';
-				case '&quot;':
-					return '"';
-				case '&apos;':
-					return "'";
-				default:
-					return entity;
-			}
-		}
-	);
-}
-
-function htmlTemplateToText(template: string): string {
-	return decodeHtmlEntities(
-		template
-			.replace(/<[^>]+>/g, ' ')
-			.replace(/\s{2,}/g, ' ')
-			.trim()
-	);
-}
-
 function plainTextTemplateWithVariables(
 	template: string,
 	vars: { signerName: string; bookingId: string; businessName: string; activityDate: string }
 ): string {
-	return resolveVariables(htmlTemplateToText(template), vars)
-		.replace(/\s{2,}/g, ' ')
-		.trim();
+	return resolveVariables(richTextHtmlToPlainText(template), vars).trim();
 }
 
 function mergeInlineStyleAttributes(attributes: string | undefined, styles: string): string {

--- a/src/convex/lib/waivers.ts
+++ b/src/convex/lib/waivers.ts
@@ -55,9 +55,12 @@ export const waiverFieldValidator = v.union(
 	})
 );
 
+export const waiverThemeValidator = v.union(v.literal('light'), v.literal('dark'));
+
 export const waiverDefinitionValidator = v.object({
 	title: v.string(),
 	introCopy: v.string(),
+	theme: v.optional(waiverThemeValidator),
 	fields: v.array(waiverFieldValidator)
 });
 
@@ -70,6 +73,7 @@ export const minorInputValidator = v.object({
 export type WaiverDefinition = {
 	title: string;
 	introCopy: string;
+	theme?: 'light' | 'dark';
 	fields: Array<
 		| {
 				id: string;
@@ -113,6 +117,7 @@ export function createDefaultWaiverDefinition(workspaceName: string): WaiverDefi
 	return normalizeWaiverDefinition({
 		title: `${workspaceName} Waiver`,
 		introCopy: '<p></p>',
+		theme: 'dark',
 		fields: []
 	});
 }
@@ -296,6 +301,7 @@ export function normalizeWaiverDefinition(definition: WaiverDefinition): WaiverD
 	return {
 		title,
 		introCopy,
+		theme: definition.theme ?? 'dark',
 		fields
 	};
 }
@@ -304,6 +310,7 @@ function normalizeWaiverDefinitionForCompare(definition: WaiverDefinition): Waiv
 	return {
 		title: definition.title.trim(),
 		introCopy: sanitizeRichTextHtml(definition.introCopy),
+		theme: definition.theme ?? 'dark',
 		fields: definition.fields.map((field) => {
 			if (field.type === 'select') {
 				return {

--- a/src/convex/schema.ts
+++ b/src/convex/schema.ts
@@ -104,6 +104,7 @@ export default defineSchema({
 		publishedVersionId: v.optional(v.id('waiver_versions')),
 		title: v.string(),
 		introCopy: v.string(),
+		theme: v.optional(v.union(v.literal('light'), v.literal('dark'))),
 		fields: v.array(
 			v.union(
 				v.object({
@@ -149,6 +150,7 @@ export default defineSchema({
 		versionNumber: v.number(),
 		title: v.string(),
 		introCopy: v.string(),
+		theme: v.optional(v.union(v.literal('light'), v.literal('dark'))),
 		fields: v.array(
 			v.union(
 				v.object({

--- a/src/convex/waivers.ts
+++ b/src/convex/waivers.ts
@@ -20,7 +20,8 @@ import {
 	waiverDefinitionsEqual,
 	waiverAnswerValueValidator,
 	waiverFieldValidator,
-	waiverDefinitionValidator
+	waiverDefinitionValidator,
+	waiverThemeValidator
 } from './lib/waivers';
 
 type FunctionCtx = QueryCtx | MutationCtx;
@@ -30,6 +31,7 @@ const workspaceWaiverValue = v.object({
 	publicSlug: v.string(),
 	title: v.string(),
 	introCopy: v.string(),
+	theme: waiverThemeValidator,
 	fields: v.array(waiverFieldValidator),
 	publishedVersionId: v.union(v.id('waiver_versions'), v.null()),
 	hasUnpublishedChanges: v.boolean()
@@ -40,6 +42,7 @@ const waiverVersionPreviewValue = v.object({
 	versionNumber: v.number(),
 	title: v.string(),
 	introCopy: v.string(),
+	theme: waiverThemeValidator,
 	fields: v.array(waiverFieldValidator),
 	workspaceName: v.string(),
 	publishedAt: v.number(),
@@ -53,6 +56,7 @@ const publicWaiverValue = v.object({
 	workspaceLogoUrl: v.union(v.string(), v.null()),
 	title: v.string(),
 	introCopy: v.string(),
+	theme: waiverThemeValidator,
 	fields: v.array(waiverFieldValidator),
 	marketingOptIn: v.union(
 		v.null(),
@@ -67,6 +71,7 @@ const publicBookingWaiverValue = v.object({
 	workspaceLogoUrl: v.union(v.string(), v.null()),
 	title: v.string(),
 	introCopy: v.string(),
+	theme: waiverThemeValidator,
 	fields: v.array(waiverFieldValidator),
 	marketingOptIn: v.union(
 		v.null(),
@@ -115,11 +120,13 @@ async function waiverHasUnpublishedChanges(ctx: FunctionCtx, waiver: Doc<'worksp
 		{
 			title: waiver.title,
 			introCopy: waiver.introCopy,
+			theme: waiver.theme,
 			fields: waiver.fields
 		},
 		{
 			title: version.title,
 			introCopy: version.introCopy,
+			theme: version.theme,
 			fields: version.fields
 		}
 	);
@@ -133,6 +140,7 @@ async function workspaceWaiverSummary(ctx: FunctionCtx, waiver: Doc<'workspace_w
 		publicSlug: waiver.publicSlug,
 		title: waiver.title,
 		introCopy: waiver.introCopy,
+		theme: waiver.theme ?? 'dark',
 		fields: waiver.fields,
 		publishedVersionId: waiver.publishedVersionId ?? null,
 		hasUnpublishedChanges
@@ -182,6 +190,7 @@ export const updateWorkspaceWaiver = mutation({
 		await ctx.db.patch(waiver._id, {
 			title: definition.title,
 			introCopy: definition.introCopy,
+			theme: definition.theme ?? 'dark',
 			fields: definition.fields
 		});
 
@@ -210,6 +219,7 @@ export const publishWorkspaceWaiver = mutation({
 		const definition = normalizeWaiverDefinition({
 			title: waiver.title,
 			introCopy: waiver.introCopy,
+			theme: waiver.theme,
 			fields: waiver.fields
 		});
 		const publishedVersionId = waiver.publishedVersionId ?? null;
@@ -225,6 +235,7 @@ export const publishWorkspaceWaiver = mutation({
 			versionNumber: await getNextVersionNumber(ctx, waiver._id),
 			title: definition.title,
 			introCopy: definition.introCopy,
+			theme: definition.theme ?? 'dark',
 			fields: definition.fields,
 			publishedAt: Date.now()
 		});
@@ -274,6 +285,7 @@ export const listWaiverVersions = query({
 			versionNumber: version.versionNumber,
 			title: version.title,
 			introCopy: version.introCopy,
+			theme: version.theme ?? 'dark',
 			fields: version.fields,
 			workspaceName: workspace.name,
 			publishedAt: version.publishedAt,
@@ -357,6 +369,7 @@ export const getSubmission = query({
 			waiver: {
 				title: version.title,
 				introCopy: version.introCopy,
+				theme: version.theme ?? 'dark',
 				fields: version.fields
 			},
 			minors: submission.minors.map((participant) => participant.fullName),
@@ -470,6 +483,7 @@ export const getPublicWaiverBySlug = query({
 			workspaceLogoUrl: workspaceLogoUrl ?? null,
 			title: version.title,
 			introCopy: version.introCopy,
+			theme: version.theme ?? 'dark',
 			fields: version.fields,
 			marketingOptIn:
 				marketingIntegration?.status === 'connected' && marketingIntegration.audienceId
@@ -532,6 +546,7 @@ export const getPublicWaiverForBooking = query({
 			workspaceLogoUrl: workspaceLogoUrl ?? null,
 			title: version.title,
 			introCopy: version.introCopy,
+			theme: version.theme ?? 'dark',
 			fields: version.fields,
 			marketingOptIn:
 				marketingIntegration?.status === 'connected' && marketingIntegration.audienceId

--- a/src/convex/waivers.ts
+++ b/src/convex/waivers.ts
@@ -10,6 +10,7 @@ import { upsertSignerCustomer } from './lib/customers';
 import { submissionSearchText } from './lib/submissions';
 import { getOwnedWorkspaceLogoUrl } from './lib/workspaces';
 import { marketingConsentLabel } from './lib/marketing';
+import { sanitizeRichTextHtml } from '../lib/utils/rich-text';
 import {
 	assertWorkspaceRecord,
 	minorInputValidator,
@@ -482,7 +483,7 @@ export const getPublicWaiverBySlug = query({
 			workspaceName: workspace.name,
 			workspaceLogoUrl: workspaceLogoUrl ?? null,
 			title: version.title,
-			introCopy: version.introCopy,
+			introCopy: sanitizeRichTextHtml(version.introCopy),
 			theme: version.theme ?? 'dark',
 			fields: version.fields,
 			marketingOptIn:
@@ -545,7 +546,7 @@ export const getPublicWaiverForBooking = query({
 			workspaceName: workspace.name,
 			workspaceLogoUrl: workspaceLogoUrl ?? null,
 			title: version.title,
-			introCopy: version.introCopy,
+			introCopy: sanitizeRichTextHtml(version.introCopy),
 			theme: version.theme ?? 'dark',
 			fields: version.fields,
 			marketingOptIn:

--- a/src/convex/workspaces.ts
+++ b/src/convex/workspaces.ts
@@ -127,6 +127,7 @@ export const createWorkspace = mutation({
 			publicSlug: createDefaultPublicWaiverSlug(slug),
 			title: waiverDefinition.title,
 			introCopy: waiverDefinition.introCopy,
+			theme: waiverDefinition.theme ?? 'dark',
 			fields: waiverDefinition.fields
 		});
 

--- a/src/lib/components/emails/RichTextEditor.svelte
+++ b/src/lib/components/emails/RichTextEditor.svelte
@@ -75,7 +75,7 @@
 	const DEFAULT_SIZE_LABEL = '14';
 	const DEFAULT_OPTION_LABEL = 'Default';
 	const DEFAULT_TOOLBAR_STATE = {
-		blockShortLabel: '<p>',
+		blockLabel: 'Paragraph',
 		alignment: 'left' as TextAlignValue,
 		bold: false,
 		italic: false,
@@ -473,10 +473,10 @@
 			return;
 		}
 
-		let blockShortLabel = '<p>';
+		let blockLabel = 'Paragraph';
 		for (let level = 1; level <= 6; level += 1) {
 			if (sourceEditor.isActive('heading', { level })) {
-				blockShortLabel = `<h${level}>`;
+				blockLabel = `Heading ${level}`;
 				break;
 			}
 		}
@@ -496,7 +496,7 @@
 		const computedStyle = getSelectionComputedStyle(sourceEditor);
 
 		toolbarState = {
-			blockShortLabel,
+			blockLabel,
 			alignment,
 			bold: sourceEditor.isActive('bold'),
 			italic: sourceEditor.isActive('italic'),
@@ -681,7 +681,7 @@
 						class="toolbar-select toolbar-select-block"
 						disabled={!editor || disabled}
 					>
-						<span class="toolbar-select-label">{toolbarState.blockShortLabel}</span>
+						<span class="toolbar-select-label">{toolbarState.blockLabel}</span>
 						<ChevronDownIcon class="size-3" />
 					</button>
 				</DropdownMenuTrigger>
@@ -689,17 +689,15 @@
 					<DropdownMenuItem
 						onclick={() => command((editor) => editor.chain().focus().setParagraph().run())}
 					>
-						<span class="font-mono text-[11px]">&lt;p&gt;</span>
 						<span>Paragraph</span>
 					</DropdownMenuItem>
 					<DropdownMenuSeparator />
 					{#each headingLevels as level (level)}
 						<DropdownMenuItem
-							class={toolbarState.blockShortLabel === `<h${level}>` ? 'font-semibold' : undefined}
+							class={toolbarState.blockLabel === `Heading ${level}` ? 'font-semibold' : undefined}
 							onclick={() =>
 								command((editor) => editor.chain().focus().toggleHeading({ level }).run())}
 						>
-							<span class="font-mono text-[11px]">{`<h${level}>`}</span>
 							<span>Heading {level}</span>
 						</DropdownMenuItem>
 					{/each}
@@ -1143,7 +1141,7 @@
 	}
 
 	.toolbar-select-block {
-		min-width: 0;
+		min-width: 4.75rem;
 	}
 
 	.toolbar-select-font {

--- a/src/lib/components/emails/RichTextEditor.svelte
+++ b/src/lib/components/emails/RichTextEditor.svelte
@@ -75,7 +75,7 @@
 	const DEFAULT_SIZE_LABEL = '14';
 	const DEFAULT_OPTION_LABEL = 'Default';
 	const DEFAULT_TOOLBAR_STATE = {
-		blockLabel: 'Paragraph',
+		blockShortLabel: 'Text',
 		alignment: 'left' as TextAlignValue,
 		bold: false,
 		italic: false,
@@ -473,10 +473,10 @@
 			return;
 		}
 
-		let blockLabel = 'Paragraph';
+		let blockShortLabel = 'Text';
 		for (let level = 1; level <= 6; level += 1) {
 			if (sourceEditor.isActive('heading', { level })) {
-				blockLabel = `Heading ${level}`;
+				blockShortLabel = `H${level}`;
 				break;
 			}
 		}
@@ -496,7 +496,7 @@
 		const computedStyle = getSelectionComputedStyle(sourceEditor);
 
 		toolbarState = {
-			blockLabel,
+			blockShortLabel,
 			alignment,
 			bold: sourceEditor.isActive('bold'),
 			italic: sourceEditor.isActive('italic'),
@@ -681,7 +681,7 @@
 						class="toolbar-select toolbar-select-block"
 						disabled={!editor || disabled}
 					>
-						<span class="toolbar-select-label">{toolbarState.blockLabel}</span>
+						<span class="toolbar-select-label">{toolbarState.blockShortLabel}</span>
 						<ChevronDownIcon class="size-3" />
 					</button>
 				</DropdownMenuTrigger>
@@ -689,16 +689,16 @@
 					<DropdownMenuItem
 						onclick={() => command((editor) => editor.chain().focus().setParagraph().run())}
 					>
-						<span>Paragraph</span>
+						Paragraph
 					</DropdownMenuItem>
 					<DropdownMenuSeparator />
 					{#each headingLevels as level (level)}
 						<DropdownMenuItem
-							class={toolbarState.blockLabel === `Heading ${level}` ? 'font-semibold' : undefined}
+							class={toolbarState.blockShortLabel === `H${level}` ? 'font-semibold' : undefined}
 							onclick={() =>
 								command((editor) => editor.chain().focus().toggleHeading({ level }).run())}
 						>
-							<span>Heading {level}</span>
+							Heading {level}
 						</DropdownMenuItem>
 					{/each}
 				</DropdownMenuContent>
@@ -1141,7 +1141,7 @@
 	}
 
 	.toolbar-select-block {
-		min-width: 4.75rem;
+		min-width: 0;
 	}
 
 	.toolbar-select-font {

--- a/src/lib/components/emails/RichTextEditor.svelte
+++ b/src/lib/components/emails/RichTextEditor.svelte
@@ -75,7 +75,7 @@
 	const DEFAULT_SIZE_LABEL = '14';
 	const DEFAULT_OPTION_LABEL = 'Default';
 	const DEFAULT_TOOLBAR_STATE = {
-		blockShortLabel: 'Text',
+		blockShortLabel: '<p>',
 		alignment: 'left' as TextAlignValue,
 		bold: false,
 		italic: false,
@@ -473,10 +473,10 @@
 			return;
 		}
 
-		let blockShortLabel = 'Text';
+		let blockShortLabel = '<p>';
 		for (let level = 1; level <= 6; level += 1) {
 			if (sourceEditor.isActive('heading', { level })) {
-				blockShortLabel = `H${level}`;
+				blockShortLabel = `<h${level}>`;
 				break;
 			}
 		}
@@ -689,16 +689,18 @@
 					<DropdownMenuItem
 						onclick={() => command((editor) => editor.chain().focus().setParagraph().run())}
 					>
-						Paragraph
+						<span class="font-mono text-[11px]">&lt;p&gt;</span>
+						<span>Paragraph</span>
 					</DropdownMenuItem>
 					<DropdownMenuSeparator />
 					{#each headingLevels as level (level)}
 						<DropdownMenuItem
-							class={toolbarState.blockShortLabel === `H${level}` ? 'font-semibold' : undefined}
+							class={toolbarState.blockShortLabel === `<h${level}>` ? 'font-semibold' : undefined}
 							onclick={() =>
 								command((editor) => editor.chain().focus().toggleHeading({ level }).run())}
 						>
-							Heading {level}
+							<span class="font-mono text-[11px]">{`<h${level}>`}</span>
+							<span>Heading {level}</span>
 						</DropdownMenuItem>
 					{/each}
 				</DropdownMenuContent>

--- a/src/lib/components/waivers/PublicWaiverForm.svelte
+++ b/src/lib/components/waivers/PublicWaiverForm.svelte
@@ -9,14 +9,13 @@
 	import WaiverPublicAboutSignerCard from '$lib/components/waivers/WaiverPublicAboutSignerCard.svelte';
 	import WaiverPublicAdditionalInfoSection from '$lib/components/waivers/WaiverPublicAdditionalInfoSection.svelte';
 	import WaiverPublicMinorsBlock from '$lib/components/waivers/WaiverPublicMinorsBlock.svelte';
-	import WaiverThemeToggle from '$lib/components/waivers/WaiverThemeToggle.svelte';
 	import {
 		waiverAddMinorButtonClass,
 		waiverFieldLabelClass,
 		waiverUnderlineInputClass,
 		waiverUnderlineTextareaClass
 	} from '$lib/components/waivers/waiver-public-form-classes';
-	import type { WaiverField, WaiverMinor } from '$lib/domain/waivers';
+	import type { WaiverField, WaiverMinor, WaiverTheme } from '$lib/domain/waivers';
 	import { getConvexErrorMessage } from '$lib/utils/convex-errors';
 	import { formatBookingTimestamp } from '$lib/utils/date';
 
@@ -27,6 +26,7 @@
 		workspaceLogoUrl: string | null;
 		title: string;
 		introCopy: string;
+		theme: WaiverTheme;
 		fields: WaiverField[];
 		marketingOptIn: { provider: 'mailchimp'; label: string } | null;
 	};
@@ -136,8 +136,11 @@
 	}
 </script>
 
-<div class="min-h-screen bg-background">
-	<WaiverThemeToggle />
+<div
+	class="min-h-screen bg-background text-foreground"
+	class:waiver-theme-light={waiver.theme === 'light'}
+	class:waiver-theme-dark={waiver.theme === 'dark'}
+>
 	<WaiverDocumentShell
 		workspaceName={waiver.workspaceName}
 		workspaceLogoUrl={waiver.workspaceLogoUrl}

--- a/src/lib/components/waivers/PublicWaiverForm.svelte
+++ b/src/lib/components/waivers/PublicWaiverForm.svelte
@@ -9,6 +9,7 @@
 	import WaiverPublicAboutSignerCard from '$lib/components/waivers/WaiverPublicAboutSignerCard.svelte';
 	import WaiverPublicAdditionalInfoSection from '$lib/components/waivers/WaiverPublicAdditionalInfoSection.svelte';
 	import WaiverPublicMinorsBlock from '$lib/components/waivers/WaiverPublicMinorsBlock.svelte';
+	import WaiverThemeToggle from '$lib/components/waivers/WaiverThemeToggle.svelte';
 	import {
 		waiverAddMinorButtonClass,
 		waiverFieldLabelClass,
@@ -136,6 +137,7 @@
 </script>
 
 <div class="min-h-screen bg-background">
+	<WaiverThemeToggle />
 	<WaiverDocumentShell
 		workspaceName={waiver.workspaceName}
 		workspaceLogoUrl={waiver.workspaceLogoUrl}

--- a/src/lib/components/waivers/SubmissionDetailSheet.svelte
+++ b/src/lib/components/waivers/SubmissionDetailSheet.svelte
@@ -277,6 +277,7 @@
 					workspaceName={submission.workspaceName}
 					introCopy={submission.waiver.introCopy}
 					fields={submission.waiver.fields}
+					theme={submission.waiver.theme ?? 'dark'}
 					signerName={submission.signerName}
 					signerEmail={submission.signerEmail}
 					signerDateOfBirth={submission.signerDateOfBirth}

--- a/src/lib/components/waivers/WaiverBuilderCanvas.svelte
+++ b/src/lib/components/waivers/WaiverBuilderCanvas.svelte
@@ -101,7 +101,7 @@
 	let linkError = $state<string | null>(null);
 	let linkInputEl = $state<HTMLInputElement | null>(null);
 	let toolbarState = $state({
-		blockShortLabel: '<p>',
+		blockLabel: 'Paragraph',
 		alignment: 'left' as TextAlignValue,
 		bold: false,
 		italic: false,
@@ -239,10 +239,10 @@
 	function syncToolbarState(sourceEditor: Editor | null) {
 		if (!sourceEditor) return;
 
-		let blockShortLabel = '<p>';
+		let blockLabel = 'Paragraph';
 		for (let level = 1; level <= 6; level += 1) {
 			if (sourceEditor.isActive('heading', { level })) {
-				blockShortLabel = `<h${level}>`;
+				blockLabel = `Heading ${level}`;
 				break;
 			}
 		}
@@ -252,7 +252,7 @@
 		) ?? 'left') as TextAlignValue;
 
 		toolbarState = {
-			blockShortLabel,
+			blockLabel,
 			alignment,
 			bold: sourceEditor.isActive('bold'),
 			italic: sourceEditor.isActive('italic'),
@@ -408,7 +408,6 @@
 				{/if}
 				<span class="truncate">{savedLabel}</span>
 			</span>
-			<WaiverThemeToggle bind:theme />
 		</div>
 
 		<div class="flex shrink-0 items-center gap-1">
@@ -417,23 +416,24 @@
 				<DropdownMenuTrigger class="toolbar-select" disabled={!editor} aria-label="Text style">
 					{#snippet child({ props })}
 						<button {...props}>
-							<span class="toolbar-select-label">{toolbarState.blockShortLabel}</span>
+							<span class="toolbar-select-label">{toolbarState.blockLabel}</span>
 							<ChevronDownIcon class="size-3" />
 						</button>
 					{/snippet}
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end" class="w-40">
-					<DropdownMenuItem onclick={() => command((e) => e.chain().focus().setParagraph().run())}>
-						<span class="font-mono text-[11px]">&lt;p&gt;</span>
+					<DropdownMenuItem
+						class={toolbarState.blockLabel === 'Paragraph' ? 'font-semibold' : undefined}
+						onclick={() => command((e) => e.chain().focus().setParagraph().run())}
+					>
 						<span>Paragraph</span>
 					</DropdownMenuItem>
 					<DropdownMenuSeparator />
 					{#each headingLevels as level (level)}
 						<DropdownMenuItem
-							class={toolbarState.blockShortLabel === `<h${level}>` ? 'font-semibold' : undefined}
+							class={toolbarState.blockLabel === `Heading ${level}` ? 'font-semibold' : undefined}
 							onclick={() => command((e) => e.chain().focus().toggleHeading({ level }).run())}
 						>
-							<span class="font-mono text-[11px]">{`<h${level}>`}</span>
 							<span>Heading {level}</span>
 						</DropdownMenuItem>
 					{/each}
@@ -591,6 +591,10 @@
 			>
 				<RemoveFormattingIcon class="size-3.5" />
 			</button>
+
+			<span class="toolbar-divider"></span>
+
+			<WaiverThemeToggle bind:theme />
 		</div>
 	</div>
 
@@ -794,7 +798,7 @@
 	}
 
 	.toolbar-select-label {
-		min-width: 1.4rem;
+		min-width: 4.75rem;
 		text-align: left;
 		font-variant: all-small-caps;
 		letter-spacing: 0.03em;

--- a/src/lib/components/waivers/WaiverBuilderCanvas.svelte
+++ b/src/lib/components/waivers/WaiverBuilderCanvas.svelte
@@ -779,7 +779,7 @@
 		align-items: center;
 		gap: 0.25rem;
 		border-radius: var(--radius-md);
-		padding: 0 0.55rem;
+		padding: 0 0.4rem;
 		font-size: 0.72rem;
 		font-weight: 500;
 		color: var(--foreground);
@@ -798,8 +798,6 @@
 	}
 
 	.toolbar-select-label {
-		min-width: 4.75rem;
-		text-align: left;
 		font-variant: all-small-caps;
 		letter-spacing: 0.03em;
 	}

--- a/src/lib/components/waivers/WaiverBuilderCanvas.svelte
+++ b/src/lib/components/waivers/WaiverBuilderCanvas.svelte
@@ -98,7 +98,7 @@
 	let linkError = $state<string | null>(null);
 	let linkInputEl = $state<HTMLInputElement | null>(null);
 	let toolbarState = $state({
-		blockShortLabel: 'Text',
+		blockShortLabel: '<p>',
 		alignment: 'left' as TextAlignValue,
 		bold: false,
 		italic: false,
@@ -236,10 +236,10 @@
 	function syncToolbarState(sourceEditor: Editor | null) {
 		if (!sourceEditor) return;
 
-		let blockShortLabel = 'Text';
+		let blockShortLabel = '<p>';
 		for (let level = 1; level <= 6; level += 1) {
 			if (sourceEditor.isActive('heading', { level })) {
-				blockShortLabel = `H${level}`;
+				blockShortLabel = `<h${level}>`;
 				break;
 			}
 		}
@@ -414,15 +414,17 @@
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end" class="w-40">
 					<DropdownMenuItem onclick={() => command((e) => e.chain().focus().setParagraph().run())}>
-						Paragraph
+						<span class="font-mono text-[11px]">&lt;p&gt;</span>
+						<span>Paragraph</span>
 					</DropdownMenuItem>
 					<DropdownMenuSeparator />
 					{#each headingLevels as level (level)}
 						<DropdownMenuItem
-							class={toolbarState.blockShortLabel === `H${level}` ? 'font-semibold' : undefined}
+							class={toolbarState.blockShortLabel === `<h${level}>` ? 'font-semibold' : undefined}
 							onclick={() => command((e) => e.chain().focus().toggleHeading({ level }).run())}
 						>
-							Heading {level}
+							<span class="font-mono text-[11px]">{`<h${level}>`}</span>
+							<span>Heading {level}</span>
 						</DropdownMenuItem>
 					{/each}
 				</DropdownMenuContent>
@@ -815,28 +817,31 @@
 	:global(.waiver-canvas-editor h4),
 	:global(.waiver-canvas-editor h5),
 	:global(.waiver-canvas-editor h6) {
-		margin: 1.5rem 0 0.75rem;
+		margin: 1.25rem 0 0.75rem;
 		font-weight: 700;
 		line-height: 1.2;
 		color: var(--foreground);
 	}
 
 	:global(.waiver-canvas-editor h1) {
-		font-size: 1.75rem;
+		font-size: 1.875rem;
 	}
 
 	:global(.waiver-canvas-editor h2) {
-		font-size: 1.375rem;
+		font-size: 1.5rem;
 	}
 
 	:global(.waiver-canvas-editor h3) {
-		font-size: 1.2rem;
+		font-size: 1.25rem;
 	}
 
-	:global(.waiver-canvas-editor h4),
+	:global(.waiver-canvas-editor h4) {
+		font-size: 1.125rem;
+	}
+
 	:global(.waiver-canvas-editor h5),
 	:global(.waiver-canvas-editor h6) {
-		font-size: 1.05rem;
+		font-size: 1rem;
 	}
 
 	:global(.waiver-canvas-editor ul),
@@ -846,6 +851,7 @@
 	}
 
 	:global(.waiver-canvas-editor li) {
+		display: list-item;
 		margin: 0.2rem 0;
 	}
 

--- a/src/lib/components/waivers/WaiverBuilderCanvas.svelte
+++ b/src/lib/components/waivers/WaiverBuilderCanvas.svelte
@@ -26,8 +26,9 @@
 	import type { Id } from '$convex/_generated/dataModel';
 	import { api } from '$convex/_generated/api';
 	import { useProtectedQuery } from '$lib/components/auth/convex-auth.svelte';
-	import type { WaiverField } from '$lib/domain/waivers';
+	import type { WaiverField, WaiverTheme } from '$lib/domain/waivers';
 	import WaiverDocumentShell from '$lib/components/waivers/WaiverDocumentShell.svelte';
+	import WaiverThemeToggle from '$lib/components/waivers/WaiverThemeToggle.svelte';
 	import WorkspaceLogoUploader from '$lib/components/workspaces/WorkspaceLogoUploader.svelte';
 	import WaiverPublicAboutSignerCard from '$lib/components/waivers/WaiverPublicAboutSignerCard.svelte';
 	import WaiverPublicAdditionalInfoSection from '$lib/components/waivers/WaiverPublicAdditionalInfoSection.svelte';
@@ -63,6 +64,7 @@
 	interface Props {
 		introCopy: string;
 		fields: WaiverField[];
+		theme?: WaiverTheme;
 		workspaceName?: string;
 		workspaceId?: Id<'workspaces'> | null;
 		canEditBranding?: boolean;
@@ -76,6 +78,7 @@
 	let {
 		introCopy = $bindable('<p></p>'),
 		fields,
+		theme = $bindable('dark'),
 		workspaceName,
 		workspaceId = null,
 		canEditBranding = false,
@@ -380,14 +383,20 @@
 <section class="flex min-h-0 min-w-0 flex-1 flex-col bg-muted/10">
 	<!-- Toolbar -->
 	<div
-		class="canvas-toolbar flex shrink-0 items-center gap-2 border-b border-border/80 bg-card/40 px-4 py-2 backdrop-blur-sm"
+		class="canvas-toolbar flex shrink-0 items-center gap-2 overflow-x-auto border-b border-border/80 bg-card/40 px-4 py-2 backdrop-blur-sm"
 		role="toolbar"
 		aria-label="Waiver copy formatting"
 		tabindex="-1"
 		onmousedown={keepToolbarFocus}
 	>
-		<div class="flex min-w-0 flex-1 items-center gap-2">
-			<span class="save-indicator" data-state={saveState}>
+		<div class="toolbar-status-cluster flex min-w-0 flex-1 items-center gap-2">
+			<span
+				class="save-indicator"
+				data-state={saveState}
+				role="status"
+				aria-label={savedLabel}
+				title={savedLabel}
+			>
 				{#if saveState === 'saving'}
 					<LoaderIcon class="size-3.5 animate-spin" />
 				{:else if saveState === 'error'}
@@ -399,9 +408,10 @@
 				{/if}
 				<span class="truncate">{savedLabel}</span>
 			</span>
+			<WaiverThemeToggle bind:theme />
 		</div>
 
-		<div class="flex items-center gap-1">
+		<div class="flex shrink-0 items-center gap-1">
 			<!-- Block style -->
 			<DropdownMenu>
 				<DropdownMenuTrigger class="toolbar-select" disabled={!editor} aria-label="Text style">
@@ -585,7 +595,12 @@
 	</div>
 
 	<!-- Scrollable document canvas -->
-	<div class="flex-1 overflow-y-auto overscroll-y-contain" data-canvas-scroll>
+	<div
+		class="flex-1 overflow-y-auto overscroll-y-contain bg-background text-foreground"
+		class:waiver-theme-light={theme === 'light'}
+		class:waiver-theme-dark={theme === 'dark'}
+		data-canvas-scroll
+	>
 		<WaiverDocumentShell {workspaceName} {workspaceLogoUrl}>
 			{#snippet headerActions()}
 				{#if workspaceId && canEditBranding}
@@ -673,6 +688,10 @@
 </section>
 
 <style>
+	.canvas-toolbar {
+		scrollbar-width: thin;
+	}
+
 	.save-indicator {
 		display: inline-flex;
 		align-items: center;
@@ -705,6 +724,20 @@
 
 	.save-indicator[data-state='dirty'] {
 		color: color-mix(in srgb, var(--primary) 70%, var(--foreground));
+	}
+
+	@media (max-width: 640px) {
+		.toolbar-status-cluster {
+			flex: 0 0 auto;
+		}
+
+		.save-indicator {
+			padding-inline: 0.4rem;
+		}
+
+		.save-indicator span {
+			display: none;
+		}
 	}
 
 	.toolbar-button {
@@ -861,7 +894,7 @@
 		text-underline-offset: 0.15em;
 	}
 
-	:global(.dark .waiver-canvas-editor a) {
+	:global(.waiver-theme-dark) :global(.waiver-canvas-editor a) {
 		color: color-mix(in oklch, var(--primary) 32%, var(--primary-foreground));
 	}
 

--- a/src/lib/components/waivers/WaiverBuilderCanvas.svelte
+++ b/src/lib/components/waivers/WaiverBuilderCanvas.svelte
@@ -885,6 +885,14 @@
 		padding-left: 1.25rem;
 	}
 
+	:global(.waiver-canvas-editor ul) {
+		list-style-type: disc;
+	}
+
+	:global(.waiver-canvas-editor ol) {
+		list-style-type: decimal;
+	}
+
 	:global(.waiver-canvas-editor li) {
 		display: list-item;
 		margin: 0.2rem 0;

--- a/src/lib/components/waivers/WaiverBuilderPanel.svelte
+++ b/src/lib/components/waivers/WaiverBuilderPanel.svelte
@@ -169,7 +169,7 @@
 			</div>
 			<DropdownMenu>
 				<DropdownMenuTrigger
-					class="h-8 shrink-0 gap-1 rounded-md px-2.5 text-[11px] font-medium tracking-wide"
+					class="h-8 shrink-0 cursor-pointer gap-1 rounded-md px-2.5 text-[11px] font-medium tracking-wide disabled:cursor-not-allowed"
 					disabled={!canAddField}
 				>
 					{#snippet child({ props })}

--- a/src/lib/components/waivers/WaiverReadonlyDocument.svelte
+++ b/src/lib/components/waivers/WaiverReadonlyDocument.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WaiverField } from '$lib/domain/waivers';
+	import type { WaiverField, WaiverTheme } from '$lib/domain/waivers';
 	import WaiverCopySection from '$lib/components/waivers/WaiverCopySection.svelte';
 	import WaiverDocumentShell from '$lib/components/waivers/WaiverDocumentShell.svelte';
 	import WaiverFieldDisplay from '$lib/components/waivers/WaiverFieldDisplay.svelte';
@@ -17,6 +17,7 @@
 		workspaceName?: string;
 		introCopy: string;
 		fields: WaiverField[];
+		theme?: WaiverTheme;
 		preview?: boolean;
 		signerName?: string;
 		signerEmail?: string;
@@ -33,6 +34,7 @@
 		workspaceName,
 		introCopy,
 		fields,
+		theme = 'dark',
 		preview = false,
 		signerName = '',
 		signerEmail = '',
@@ -57,7 +59,11 @@
 	}
 </script>
 
-<div class="bg-background">
+<div
+	class="bg-background text-foreground"
+	class:waiver-theme-light={theme === 'light'}
+	class:waiver-theme-dark={theme === 'dark'}
+>
 	<WaiverDocumentShell {workspaceName}>
 		<WaiverCopySection {introCopy} />
 

--- a/src/lib/components/waivers/WaiverRichText.svelte
+++ b/src/lib/components/waivers/WaiverRichText.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import { sanitizeRichTextHtml } from '$lib/utils/rich-text-client';
 
 	interface Props {
@@ -8,7 +9,14 @@
 
 	let { html, class: className = '' }: Props = $props();
 
-	const sanitizedHtml = $derived(sanitizeRichTextHtml(html));
+	/**
+	 * The client sanitizer needs DOMParser, which does not exist during SSR. Running
+	 * it there falls back to the plain-text path and escapes the whole document, so
+	 * the markup renders as visible tags and hydration keeps that server output.
+	 * Server-rendered callers therefore pass HTML that was already sanitized on the
+	 * way out of Convex; the browser still re-sanitizes on hydration.
+	 */
+	const sanitizedHtml = $derived(browser ? sanitizeRichTextHtml(html) : html.trim());
 </script>
 
 {#if sanitizedHtml}

--- a/src/lib/components/waivers/WaiverRichText.svelte
+++ b/src/lib/components/waivers/WaiverRichText.svelte
@@ -80,7 +80,7 @@
 		text-underline-offset: 0.15em;
 	}
 
-	:global(.dark) .waiver-rich-text :global(a) {
+	:global(.waiver-theme-dark) .waiver-rich-text :global(a) {
 		color: color-mix(in oklch, var(--primary) 32%, var(--primary-foreground));
 	}
 

--- a/src/lib/components/waivers/WaiverThemeToggle.svelte
+++ b/src/lib/components/waivers/WaiverThemeToggle.svelte
@@ -1,28 +1,82 @@
 <script lang="ts">
-	import { mode as themeMode, setMode } from 'mode-watcher';
 	import MoonStarIcon from '@lucide/svelte/icons/moon-star';
 	import SunIcon from '@lucide/svelte/icons/sun';
+	import type { WaiverTheme } from '$lib/domain/waivers';
 
-	const isDark = $derived(themeMode.current === 'dark');
-	const actionLabel = $derived(isDark ? 'Switch to light mode' : 'Switch to dark mode');
-
-	function toggleTheme() {
-		setMode(isDark ? 'light' : 'dark');
+	interface Props {
+		theme?: WaiverTheme;
 	}
+
+	let { theme = $bindable('dark') }: Props = $props();
 </script>
 
-<button
-	type="button"
-	class="fixed top-3 right-3 z-20 inline-flex size-9 cursor-pointer items-center justify-center rounded-full border border-border bg-card/90 text-xs font-semibold text-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:outline-none sm:top-4 sm:right-4 sm:w-auto sm:gap-2 sm:px-3"
-	onclick={toggleTheme}
-	aria-label={actionLabel}
-	title={actionLabel}
->
-	{#if isDark}
+<div class="theme-control" role="group" aria-label="Waiver appearance">
+	<button
+		type="button"
+		class="theme-option"
+		class:is-active={theme === 'light'}
+		aria-pressed={theme === 'light'}
+		aria-label="Preview waiver in light mode"
+		title="Light waiver"
+		onclick={() => (theme = 'light')}
+	>
 		<SunIcon class="size-3.5" aria-hidden="true" />
-		<span class="hidden sm:inline">Light</span>
-	{:else}
+	</button>
+	<button
+		type="button"
+		class="theme-option"
+		class:is-active={theme === 'dark'}
+		aria-pressed={theme === 'dark'}
+		aria-label="Preview waiver in dark mode"
+		title="Dark waiver"
+		onclick={() => (theme = 'dark')}
+	>
 		<MoonStarIcon class="size-3.5" aria-hidden="true" />
-		<span class="hidden sm:inline">Dark</span>
-	{/if}
-</button>
+	</button>
+</div>
+
+<style>
+	.theme-control {
+		display: inline-flex;
+		flex: 0 0 auto;
+		align-items: center;
+		gap: 0.125rem;
+		padding: 0.125rem;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		background: color-mix(in srgb, var(--muted) 35%, transparent);
+	}
+
+	.theme-option {
+		display: inline-flex;
+		height: 1.5rem;
+		width: 1.5rem;
+		align-items: center;
+		justify-content: center;
+		padding: 0;
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		font-size: 0.67rem;
+		font-weight: 600;
+		color: var(--muted-foreground);
+		transition:
+			background-color 150ms ease,
+			color 150ms ease,
+			box-shadow 150ms ease;
+	}
+
+	.theme-option:hover {
+		color: var(--foreground);
+	}
+
+	.theme-option.is-active {
+		background: var(--background);
+		color: var(--foreground);
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+	}
+
+	.theme-option:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 45%, transparent);
+	}
+</style>

--- a/src/lib/components/waivers/WaiverThemeToggle.svelte
+++ b/src/lib/components/waivers/WaiverThemeToggle.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { mode as themeMode, setMode } from 'mode-watcher';
+	import MoonStarIcon from '@lucide/svelte/icons/moon-star';
+	import SunIcon from '@lucide/svelte/icons/sun';
+
+	const isDark = $derived(themeMode.current === 'dark');
+	const actionLabel = $derived(isDark ? 'Switch to light mode' : 'Switch to dark mode');
+
+	function toggleTheme() {
+		setMode(isDark ? 'light' : 'dark');
+	}
+</script>
+
+<button
+	type="button"
+	class="fixed top-3 right-3 z-20 inline-flex size-9 cursor-pointer items-center justify-center rounded-full border border-border bg-card/90 text-xs font-semibold text-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:outline-none sm:top-4 sm:right-4 sm:w-auto sm:gap-2 sm:px-3"
+	onclick={toggleTheme}
+	aria-label={actionLabel}
+	title={actionLabel}
+>
+	{#if isDark}
+		<SunIcon class="size-3.5" aria-hidden="true" />
+		<span class="hidden sm:inline">Light</span>
+	{:else}
+		<MoonStarIcon class="size-3.5" aria-hidden="true" />
+		<span class="hidden sm:inline">Dark</span>
+	{/if}
+</button>

--- a/src/lib/components/waivers/WaiverThemeToggle.svelte
+++ b/src/lib/components/waivers/WaiverThemeToggle.svelte
@@ -56,8 +56,6 @@
 		padding: 0;
 		border-radius: var(--radius-sm);
 		cursor: pointer;
-		font-size: 0.67rem;
-		font-weight: 600;
 		color: var(--muted-foreground);
 		transition:
 			background-color 150ms ease,

--- a/src/lib/components/waivers/WaiverVersionHistorySheet.svelte
+++ b/src/lib/components/waivers/WaiverVersionHistorySheet.svelte
@@ -150,6 +150,7 @@
 					workspaceName={selected.workspaceName}
 					introCopy={selected.introCopy}
 					fields={selected.fields}
+					theme={selected.theme}
 					preview
 				/>
 			</div>

--- a/src/lib/domain/waivers.ts
+++ b/src/lib/domain/waivers.ts
@@ -12,6 +12,7 @@ import {
 } from '$lib/domain/waiver-constraints';
 
 export type WaiverFieldType = 'text' | 'checkbox' | 'select' | 'date';
+export type WaiverTheme = 'light' | 'dark';
 
 export type WaiverField =
 	| {
@@ -48,6 +49,7 @@ export type WaiverDefinition = {
 	title: string;
 	introCopy: string;
 	fields: WaiverField[];
+	theme: WaiverTheme;
 };
 
 export type WorkspaceWaiverRecord = WaiverDefinition & {
@@ -64,6 +66,7 @@ export type PublicWaiverRecord = {
 	title: string;
 	introCopy: string;
 	fields: WaiverField[];
+	theme: WaiverTheme;
 };
 
 export type WaiverMinor = {
@@ -140,7 +143,8 @@ export function createBlankDefinition(title = 'New waiver'): WaiverDefinition {
 	return {
 		title,
 		introCopy: '<p></p>',
-		fields: []
+		fields: [],
+		theme: 'dark'
 	};
 }
 
@@ -148,6 +152,7 @@ export function cloneDefinition(definition: WaiverDefinition): WaiverDefinition 
 	return {
 		title: definition.title,
 		introCopy: sanitizeRichTextHtml(definition.introCopy),
+		theme: definition.theme ?? 'dark',
 		fields: definition.fields.map((field) => {
 			if (field.type === 'select') {
 				return {
@@ -207,6 +212,7 @@ export function normalizeDefinitionForCompare(definition: WaiverDefinition): Wai
 	return {
 		title: definition.title.trim(),
 		introCopy: sanitizeRichTextHtml(definition.introCopy),
+		theme: definition.theme ?? 'dark',
 		fields: definition.fields.map((field) => {
 			if (field.type === 'select') {
 				return {

--- a/src/lib/utils/rich-text-client.ts
+++ b/src/lib/utils/rich-text-client.ts
@@ -6,6 +6,7 @@ import {
 	TAG_RENAMES,
 	finalizeSanitizedRichTextHtml,
 	hasSupportedHtmlTag,
+	normalizeRichTextSource,
 	plainTextToRichHtml,
 	sanitizeHref,
 	sanitizeStyle
@@ -110,7 +111,7 @@ function browserSanitizeHtml(source: string): string | null {
 }
 
 export function sanitizeRichTextHtml(input: string): string {
-	const source = input.replace(/\r\n?/g, '\n').trim();
+	const source = normalizeRichTextSource(input);
 	if (!source) return '';
 
 	if (!hasSupportedHtmlTag(source)) {

--- a/src/lib/utils/rich-text-shared.ts
+++ b/src/lib/utils/rich-text-shared.ts
@@ -100,28 +100,6 @@ export function hasSupportedHtmlTag(input: string): boolean {
 	return /<\/?[a-z][^>]*>/i.test(input);
 }
 
-const ESCAPED_TAG_START_PATTERN = /&(?:lt|#0*60|#x0*3c);[/a-z]/i;
-
-/**
- * An earlier editor pass could load an entity-encoded document as plain text
- * and save it back wrapped in a paragraph, so the encoded tags render as
- * visible text. Recover the original markup only when the whole visible text
- * of the document is itself a block-level HTML document, which leaves prose
- * that merely mentions a tag name untouched.
- */
-function unwrapEncodedMarkupDocument(source: string): string | null {
-	if (!ESCAPED_TAG_START_PATTERN.test(source)) return null;
-
-	const text = source.replace(/<[^>]*>/g, '').trim();
-	if (!text) return null;
-
-	const decoded = decodeHtml(text).trim();
-	if (decoded === text || !decoded.startsWith('<') || !decoded.endsWith('>')) return null;
-	if (!BLOCK_TAG_REGEX.test(decoded)) return null;
-
-	return decoded;
-}
-
 /**
  * Older rich-text values can contain an entity-encoded HTML document. Decode
  * that wrapper before sanitizing so its tags render instead of appearing as
@@ -129,17 +107,7 @@ function unwrapEncodedMarkupDocument(source: string): string | null {
  */
 export function normalizeRichTextSource(input: string): string {
 	const source = input.replace(/\r\n?/g, '\n').trim();
-	if (!source) return source;
-
-	if (hasSupportedHtmlTag(source)) {
-		let unwrapped = source;
-		for (let pass = 0; pass < 4; pass += 1) {
-			const candidate = unwrapEncodedMarkupDocument(unwrapped);
-			if (!candidate) break;
-			unwrapped = candidate;
-		}
-		return unwrapped;
-	}
+	if (!source || hasSupportedHtmlTag(source)) return source;
 
 	let decoded = source;
 	for (let pass = 0; pass < 4; pass += 1) {

--- a/src/lib/utils/rich-text-shared.ts
+++ b/src/lib/utils/rich-text-shared.ts
@@ -58,17 +58,59 @@ export function escapeHtml(value: string): string {
 }
 
 export function decodeHtml(value: string): string {
-	return value
-		.replaceAll('&nbsp;', ' ')
-		.replaceAll('&lt;', '<')
-		.replaceAll('&gt;', '>')
-		.replaceAll('&quot;', '"')
-		.replaceAll('&#39;', "'")
-		.replaceAll('&amp;', '&');
+	return value.replace(
+		/&(#(\d+)|#x([\da-f]+)|nbsp|amp|lt|gt|quot|apos);/gi,
+		(entity, _match, decimal, hexadecimal) => {
+			if (decimal || hexadecimal) {
+				const codePoint = decimal ? Number.parseInt(decimal, 10) : Number.parseInt(hexadecimal, 16);
+
+				if (
+					!Number.isInteger(codePoint) ||
+					codePoint < 0 ||
+					codePoint > 0x10ffff ||
+					(codePoint >= 0xd800 && codePoint <= 0xdfff)
+				) {
+					return entity;
+				}
+
+				return String.fromCodePoint(codePoint);
+			}
+
+			switch (entity.toLowerCase()) {
+				case '&nbsp;':
+					return ' ';
+				case '&amp;':
+					return '&';
+				case '&lt;':
+					return '<';
+				case '&gt;':
+					return '>';
+				case '&quot;':
+					return '"';
+				case '&apos;':
+					return "'";
+				default:
+					return entity;
+			}
+		}
+	);
 }
 
 export function hasSupportedHtmlTag(input: string): boolean {
 	return /<\/?[a-z][^>]*>/i.test(input);
+}
+
+/**
+ * Older rich-text values can contain an entity-encoded HTML document. Decode
+ * that wrapper before sanitizing so its tags render instead of appearing as
+ * visible text. Plain text with ordinary entities remains plain text.
+ */
+export function normalizeRichTextSource(input: string): string {
+	const source = input.replace(/\r\n?/g, '\n').trim();
+	if (!source || hasSupportedHtmlTag(source)) return source;
+
+	const decoded = decodeHtml(source);
+	return hasSupportedHtmlTag(decoded) ? decoded : source;
 }
 
 export function sanitizeHref(value: string | null): string | null {
@@ -93,6 +135,27 @@ export function plainTextToRichHtml(input: string): string {
 	});
 
 	return paragraphs.join('');
+}
+
+/** Convert sanitized rich-text HTML into the plain-text alternative used by email clients. */
+export function richTextHtmlToPlainText(input: string): string {
+	const source = normalizeRichTextSource(input);
+	if (!source) return '';
+
+	return decodeHtml(
+		source
+			.replace(/<br\s*\/?>/gi, '\n')
+			.replace(/<li\b[^>]*>/gi, '- ')
+			.replace(/<\/(?:p|h[1-6])\s*>/gi, '\n\n')
+			.replace(/<\/li\s*>/gi, '\n')
+			.replace(/<[^>]+>/g, '')
+	)
+		.replace(/\u00a0/g, ' ')
+		.replace(/[ \t]+\n/g, '\n')
+		.replace(/\n[ \t]+/g, '\n')
+		.replace(/[ \t]{2,}/g, ' ')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim();
 }
 
 export function sanitizeStyle(tagName: string, style: string | null): string | null {

--- a/src/lib/utils/rich-text-shared.ts
+++ b/src/lib/utils/rich-text-shared.ts
@@ -109,8 +109,15 @@ export function normalizeRichTextSource(input: string): string {
 	const source = input.replace(/\r\n?/g, '\n').trim();
 	if (!source || hasSupportedHtmlTag(source)) return source;
 
-	const decoded = decodeHtml(source);
-	return hasSupportedHtmlTag(decoded) ? decoded : source;
+	let decoded = source;
+	for (let pass = 0; pass < 4; pass += 1) {
+		const next = decodeHtml(decoded);
+		if (next === decoded) break;
+		decoded = next;
+		if (hasSupportedHtmlTag(decoded)) return decoded;
+	}
+
+	return source;
 }
 
 export function sanitizeHref(value: string | null): string | null {

--- a/src/lib/utils/rich-text-shared.ts
+++ b/src/lib/utils/rich-text-shared.ts
@@ -100,6 +100,28 @@ export function hasSupportedHtmlTag(input: string): boolean {
 	return /<\/?[a-z][^>]*>/i.test(input);
 }
 
+const ESCAPED_TAG_START_PATTERN = /&(?:lt|#0*60|#x0*3c);[/a-z]/i;
+
+/**
+ * An earlier editor pass could load an entity-encoded document as plain text
+ * and save it back wrapped in a paragraph, so the encoded tags render as
+ * visible text. Recover the original markup only when the whole visible text
+ * of the document is itself a block-level HTML document, which leaves prose
+ * that merely mentions a tag name untouched.
+ */
+function unwrapEncodedMarkupDocument(source: string): string | null {
+	if (!ESCAPED_TAG_START_PATTERN.test(source)) return null;
+
+	const text = source.replace(/<[^>]*>/g, '').trim();
+	if (!text) return null;
+
+	const decoded = decodeHtml(text).trim();
+	if (decoded === text || !decoded.startsWith('<') || !decoded.endsWith('>')) return null;
+	if (!BLOCK_TAG_REGEX.test(decoded)) return null;
+
+	return decoded;
+}
+
 /**
  * Older rich-text values can contain an entity-encoded HTML document. Decode
  * that wrapper before sanitizing so its tags render instead of appearing as
@@ -107,7 +129,17 @@ export function hasSupportedHtmlTag(input: string): boolean {
  */
 export function normalizeRichTextSource(input: string): string {
 	const source = input.replace(/\r\n?/g, '\n').trim();
-	if (!source || hasSupportedHtmlTag(source)) return source;
+	if (!source) return source;
+
+	if (hasSupportedHtmlTag(source)) {
+		let unwrapped = source;
+		for (let pass = 0; pass < 4; pass += 1) {
+			const candidate = unwrapEncodedMarkupDocument(unwrapped);
+			if (!candidate) break;
+			unwrapped = candidate;
+		}
+		return unwrapped;
+	}
 
 	let decoded = source;
 	for (let pass = 0; pass < 4; pass += 1) {

--- a/src/lib/utils/rich-text.ts
+++ b/src/lib/utils/rich-text.ts
@@ -9,6 +9,7 @@ import {
 	TEXT_ALIGN_PATTERNS,
 	finalizeSanitizedRichTextHtml,
 	hasSupportedHtmlTag,
+	normalizeRichTextSource,
 	plainTextToRichHtml,
 	sanitizeHref
 } from './rich-text-shared';
@@ -92,7 +93,7 @@ const SANITIZE_OPTIONS: import('sanitize-html').IOptions = {
 };
 
 export function sanitizeRichTextHtml(input: string): string {
-	const source = input.replace(/\r\n?/g, '\n').trim();
+	const source = normalizeRichTextSource(input);
 	if (!source) {
 		return '';
 	}

--- a/src/routes/(app)/app/[workspaceSlug]/waiver/+page.svelte
+++ b/src/routes/(app)/app/[workspaceSlug]/waiver/+page.svelte
@@ -872,6 +872,7 @@
 					{#if draft}
 						<WaiverBuilderCanvas
 							bind:introCopy={draft.introCopy}
+							bind:theme={draft.theme}
 							fields={currentDraft.fields}
 							workspaceName={currentWorkspace?.name}
 							workspaceId={currentWorkspace?.workspaceId ?? null}

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -5,7 +5,9 @@
 
 @custom-variant dark (&:is(.dark *));
 
-:root {
+:root,
+.waiver-theme-light {
+	color-scheme: light;
 	--background: oklch(1 0 0);
 	--foreground: oklch(0.141 0.005 285.823);
 	--card: oklch(0.985 0.001 286.375);
@@ -40,7 +42,9 @@
 	--sidebar-ring: oklch(0.705 0.015 286.067);
 }
 
-.dark {
+.dark,
+.waiver-theme-dark {
+	color-scheme: dark;
 	--background: oklch(0.141 0.005 285.823);
 	--foreground: oklch(0.985 0 0);
 	--card: oklch(0.185 0.006 285.885);

--- a/src/routes/w/+layout.svelte
+++ b/src/routes/w/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { setupConvex } from 'convex-svelte';
+	import { ModeWatcher } from 'mode-watcher';
 	import { Toaster } from '$lib/components/ui/sonner';
 	import { publicEnv } from '$lib/config/public';
 
@@ -8,5 +9,6 @@
 	let { children } = $props();
 </script>
 
+<ModeWatcher defaultMode="dark" />
 {@render children()}
 <Toaster richColors position="top-right" closeButton />

--- a/src/routes/w/+layout.svelte
+++ b/src/routes/w/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { setupConvex } from 'convex-svelte';
-	import { ModeWatcher } from 'mode-watcher';
 	import { Toaster } from '$lib/components/ui/sonner';
 	import { publicEnv } from '$lib/config/public';
 
@@ -9,6 +8,5 @@
 	let { children } = $props();
 </script>
 
-<ModeWatcher defaultMode="dark" />
 {@render children()}
 <Toaster richColors position="top-right" closeButton />

--- a/tests/richText.test.ts
+++ b/tests/richText.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	decodeHtml,
+	normalizeRichTextSource,
+	richTextHtmlToPlainText
+} from '../src/lib/utils/rich-text-shared.ts';
+
+test('normalizes entity-encoded rich text before sanitization', () => {
+	const encoded = '&lt;p&gt;Read &lt;strong&gt;every term&lt;/strong&gt; before signing.&lt;/p&gt;';
+
+	assert.equal(
+		normalizeRichTextSource(encoded),
+		'<p>Read <strong>every term</strong> before signing.</p>'
+	);
+});
+
+test('leaves ordinary entity-encoded plain text on the plain-text path', () => {
+	assert.equal(normalizeRichTextSource('Terms &amp; conditions'), 'Terms &amp; conditions');
+});
+
+test('removes actual and entity-encoded tags from email plain text', () => {
+	const template =
+		'&lt;p&gt;Hello {{customer_name}},&lt;/p&gt;&lt;p&gt;Your booking is &lt;strong&gt;confirmed&lt;/strong&gt;.&lt;br&gt;See you soon.&lt;/p&gt;';
+
+	assert.equal(
+		richTextHtmlToPlainText(template),
+		'Hello {{customer_name}},\n\nYour booking is confirmed.\nSee you soon.'
+	);
+	assert.doesNotMatch(richTextHtmlToPlainText(template), /<\/?[a-z][^>]*>/i);
+});
+
+test('decodes numeric whitespace and named entities safely', () => {
+	assert.equal(decodeHtml('Waiver&#x20;Director &amp; Co.&#32;'), 'Waiver Director & Co. ');
+	assert.equal(decodeHtml('Invalid: &#99999999;'), 'Invalid: &#99999999;');
+});

--- a/tests/richText.test.ts
+++ b/tests/richText.test.ts
@@ -40,31 +40,3 @@ test('decodes numeric whitespace and named entities safely', () => {
 	assert.equal(decodeHtml('Waiver&#x20;Director &amp; Co.&#32;'), 'Waiver Director & Co. ');
 	assert.equal(decodeHtml('Invalid: &#99999999;'), 'Invalid: &#99999999;');
 });
-
-test('unwraps encoded markup that a previous editor pass wrapped in a paragraph', () => {
-	const wrapped =
-		'<p>&lt;p&gt;Please review this participation agreement before your activity.&lt;/p&gt;</p>';
-
-	assert.equal(
-		normalizeRichTextSource(wrapped),
-		'<p>Please review this participation agreement before your activity.</p>'
-	);
-});
-
-test('unwraps encoded markup spread across several wrapper blocks', () => {
-	const wrapped = '<p>&lt;p&gt;Line one.&lt;/p&gt;</p><p>&lt;p&gt;Line two.&lt;/p&gt;</p>';
-
-	assert.equal(normalizeRichTextSource(wrapped), '<p>Line one.</p><p>Line two.</p>');
-});
-
-test('keeps literal tag names that are part of the prose', () => {
-	const prose = '<p>Wrap each clause in a &lt;p&gt; tag before importing.</p>';
-
-	assert.equal(normalizeRichTextSource(prose), prose);
-});
-
-test('keeps encoded markup that is only part of a larger document', () => {
-	const mixed = '<p>Example:</p><p>&lt;p&gt;Signed copy&lt;/p&gt;</p><p>End of example.</p>';
-
-	assert.equal(normalizeRichTextSource(mixed), mixed);
-});

--- a/tests/richText.test.ts
+++ b/tests/richText.test.ts
@@ -40,3 +40,31 @@ test('decodes numeric whitespace and named entities safely', () => {
 	assert.equal(decodeHtml('Waiver&#x20;Director &amp; Co.&#32;'), 'Waiver Director & Co. ');
 	assert.equal(decodeHtml('Invalid: &#99999999;'), 'Invalid: &#99999999;');
 });
+
+test('unwraps encoded markup that a previous editor pass wrapped in a paragraph', () => {
+	const wrapped =
+		'<p>&lt;p&gt;Please review this participation agreement before your activity.&lt;/p&gt;</p>';
+
+	assert.equal(
+		normalizeRichTextSource(wrapped),
+		'<p>Please review this participation agreement before your activity.</p>'
+	);
+});
+
+test('unwraps encoded markup spread across several wrapper blocks', () => {
+	const wrapped = '<p>&lt;p&gt;Line one.&lt;/p&gt;</p><p>&lt;p&gt;Line two.&lt;/p&gt;</p>';
+
+	assert.equal(normalizeRichTextSource(wrapped), '<p>Line one.</p><p>Line two.</p>');
+});
+
+test('keeps literal tag names that are part of the prose', () => {
+	const prose = '<p>Wrap each clause in a &lt;p&gt; tag before importing.</p>';
+
+	assert.equal(normalizeRichTextSource(prose), prose);
+});
+
+test('keeps encoded markup that is only part of a larger document', () => {
+	const mixed = '<p>Example:</p><p>&lt;p&gt;Signed copy&lt;/p&gt;</p><p>End of example.</p>';
+
+	assert.equal(normalizeRichTextSource(mixed), mixed);
+});

--- a/tests/richText.test.ts
+++ b/tests/richText.test.ts
@@ -15,6 +15,12 @@ test('normalizes entity-encoded rich text before sanitization', () => {
 	);
 });
 
+test('normalizes repeatedly encoded legacy rich text before sanitization', () => {
+	const encoded = '&amp;lt;p&amp;gt;Please review this agreement.&amp;lt;/p&amp;gt;';
+
+	assert.equal(normalizeRichTextSource(encoded), '<p>Please review this agreement.</p>');
+});
+
 test('leaves ordinary entity-encoded plain text on the plain-text path', () => {
 	assert.equal(normalizeRichTextSource('Terms &amp; conditions'), 'Terms &amp; conditions');
 });


### PR DESCRIPTION
## Summary

- move the light/dark appearance control into the waiver editor and save the selected theme with both the draft and immutable published version
- render published waivers in the configured theme without exposing a signer-facing theme toggle; older waivers safely default to dark
- render waiver rich text as sanitized HTML without showing encoded tags in published waivers or follow-up email text
- keep preview typography aligned with published output, including explicit unordered and ordered list markers
- show actual HTML block tags in the rich-text controls and use the expected interactive cursor on Add field
- add regression coverage for encoded markup, numeric entities, and email plain-text conversion

## Validation

- `pnpm test` — 8 tests passed
- `pnpm run check` — 0 errors and 0 warnings
- `pnpm run build` — passed
- targeted Prettier and ESLint checks — passed for all changed files
- browser QA — verified editor-only theme controls, dark/light preview rendering, no public theme control, published theme fallback, and 390×844 responsive layout without page overflow

## Known baseline

- `pnpm run lint` remains blocked by repository-wide Prettier drift across pre-existing files; every file changed by this PR passes targeted Prettier and ESLint checks
- the Impeccable detector reports an existing bounce-easing value in the waiver page that this PR does not modify

## Deployment / schema

- adds optional `theme` fields to `workspace_waivers` and `waiver_versions`; no backfill or breaking migration is required because existing records resolve to dark
- no credentials, environment configuration, or deployment changes required
